### PR TITLE
Replace os.makedirs() with 'mkdir -p'

### DIFF
--- a/cmsBuild
+++ b/cmsBuild
@@ -4,7 +4,7 @@
 #
 
 from os.path import abspath, join, exists, isdir, basename, dirname
-from os import popen, makedirs, getenv, symlink, listdir, readlink, unlink, getpid
+from os import popen, getenv, symlink, listdir, readlink, unlink, getpid
 from os import chdir, getcwd, environ, walk, sep, kill
 from getpass import getuser
 from tempfile import mkdtemp, mkstemp, NamedTemporaryFile
@@ -70,6 +70,11 @@ def isOnline(arch):
 def isDefaultRevision(rev):
     if rev == '1' or rev.startswith('1.'): return True
     return False
+
+def makedirs(path):
+  returncode, out = getstatusoutput("mkdir -p %s" % (path,))
+  if returncode != 0:
+    raise OSError("makedirs() failed (return: %s):\n%s" % (returncode, out)) 
 
 # A recursive globbing helper.
 def recursive_glob(treeroot, pattern):


### PR DESCRIPTION
Resolves issue with concurrent workers creating directories. E.g.,

File "PKGTOOLS/cmsBuild", line 2805, in buildPackage
makedirs (pkg.builddir)
File "/usr/lib64/python2.4/os.py", line 156, in makedirs
makedirs(head, mode)
File "/usr/lib64/python2.4/os.py", line 156, in makedirs
makedirs(head, mode)
File "/usr/lib64/python2.4/os.py", line 159, in makedirs
mkdir(name, mode)
OSError: [Errno 17] File exists: '/<snip>/a/BUILD/slc5_amd64_gcc472/external'

Currently only tested on SLC5 rebuilding python and everything up.

Signed-off-by: David Abdurachmanov david.abdurachmanov@gmail.com
