### PR TITLE
[V00-22-XX] Misc. bugfixes and updates

### DIFF
--- a/build_rpm.sh
+++ b/build_rpm.sh
@@ -76,7 +76,7 @@ esac
 
 [ "X${ARCH}" = X ] && echo "Please specify an architecture via --arch flag" && exit 1 
 case ${ARCH} in
-  *_amd64_*)
+  *_amd64_*|*_mic_*)
     NSPR_CONFIGURE_OPTS="--enable-64bit"
     NSS_USE_64=1
   ;;

--- a/build_rpm.sh
+++ b/build_rpm.sh
@@ -4,7 +4,16 @@
 
 PREFIX=/usr/local/bin
 BUILDPROCESSES=2
-CONFIG_BUILD=auto
+case ${ARCH} in
+  osx*)
+    # Darwin is not RPM based, explicitly go for quessing the triplet
+    CONFIG_BUILD=quess
+    ;;
+  *)
+    # Assume Linux distro is RPM based and fetch triplet from RPM
+    CONFIG_BUILD=auto
+    ;;
+esac
 
 while [ $# -gt 0 ]
 do

--- a/build_rpm.sh
+++ b/build_rpm.sh
@@ -136,7 +136,7 @@ CONFIG_HOST=$CONFIG_BUILD
 # Fetch the sources.
 curl -k -s -S https://ftp.mozilla.org/pub/mozilla.org/nspr/releases/v4.9.5/src/nspr-4.9.5.tar.gz | tar xvz
 curl -k -s -S http://rpm5.org/files/popt/popt-1.16.tar.gz | tar xvz
-[ ! $IS_ONLINE ] && curl -k -s -S http://zlib.net/zlib-1.2.7.tar.bz2 | tar xvj
+[ ! $IS_ONLINE ] && curl -k -s -S http://zlib.net/zlib-1.2.8.tar.gz | tar xvz
 curl -k -s -S https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/NSS_3_14_3_RTM/src/nss-3.14.3.tar.gz | tar xvz
 curl -k -s -S ftp://ftp.fu-berlin.de/unix/tools/file/file-5.13.tar.gz | tar xvz
 curl -k -s -S http://download.oracle.com/berkeley-db/db-4.5.20.tar.gz | tar xvz
@@ -145,7 +145,7 @@ curl -k -s -S http://ftp.gnu.org/gnu/cpio/cpio-2.11.tar.bz2 | tar xvj
 
 # Build required externals.
 if [ ! $IS_ONLINE ]; then
-cd $HERE/zlib-1.2.7
+cd $HERE/zlib-1.2.8
 CFLAGS="-fPIC -O3 -DUSE_MMAP -DUNALIGNED_OK -D_LARGEFILE64_SOURCE=1" \
   ./configure --prefix $PREFIX --static
 make -j $BUILDPROCESSES && make install

--- a/cmsBuild
+++ b/cmsBuild
@@ -3197,7 +3197,7 @@ def buildSpecsNew(topLevelPackages):
   scheduler = Scheduler(pkg.options.workersPoolSize)
 
   for p in packages:
-    scheduler.serial("check-%s" % pkg.pkgName(), [], checkPackageInCache, p, scheduler)
+    scheduler.serial("check-%s" % p.pkgName(), [], checkPackageInCache, p, scheduler)
 
   # We create before hand since we know they are going to be needed. This
   # is to avoid having parallel threads creating them at the same time with

--- a/cmsBuild
+++ b/cmsBuild
@@ -3246,13 +3246,18 @@ def build(opts, args, factory):
   buildSpecsNew(packages)
 
 def isPackageInstalled(pkg):
-    pkgName = pkg.pkgName ()
-    if rpm_db_cache.has_key(pkgName):
-        if not isDefaultRevision(pkg.pkgRevision):
-            if rpm_db_cache[pkgName] < pkg.pkgRevision:
-                return False
-        log ("Package %s with same/newer revision %s is already installed" % (pkgName, str(rpm_db_cache[pkgName])), DEBUG)
-        return True
+    if pkg.options.bootstrap:
+        pkgName = pkg.pkgName ()
+        if rpm_db_cache.has_key(pkgName):
+            if not isDefaultRevision(pkg.pkgRevision):
+                if rpm_db_cache[pkgName] < pkg.pkgRevision:
+                    return False
+            log ("Package %s with same/newer revision %s is already installed" % (pkgName, str(rpm_db_cache[pkgName])), DEBUG)
+            return True
+    else:
+        instDir = join(pkg.options.workDir, pkg.pkgrel)
+        if exists(join(instDir, ".package-checksum")):
+            return True
     return False
 
 def fetch (opts, args, factory):

--- a/scheduler.py
+++ b/scheduler.py
@@ -166,6 +166,8 @@ class Scheduler(object):
     self.resultsQueue.put((threading.currentThread(), commandSpec))
 
   def serial(self, taskId, deps, *commandSpec):
+    if taskId in self.pendingJobs:    
+      self.log("Double task %s" % taskId)
     spec = [self.doSerial, taskId, deps] + list(commandSpec)
     self.resultsQueue.put((threading.currentThread(), spec))
     self.jobs[taskId] = {"scheduler": "serial", "deps": deps, "spec": spec}


### PR DESCRIPTION
**ChangeLog**
- Update _zlib_ to 1.2.8 to match _zlib_ from CMSDIST
- On Darwin use _config.guess_ to get correct machine triplet.
- Enable 64-bit builds for _NSS_ and _NSPR_ on Xeon Phi targets.
- Fix issue where we queue N times `check-<top_level_package>` task, where N is a number of dependencies, i.e., packages we actually need to build. In additional make sure that `serial()` can inform about duplicate tasks, same as `parallel()`.
- Update `isPackageInstalled()` to work with `--no-bootstrap` option, otherwise we add non-existent `install-*` jobs as dependencies and new scheduler goes into a loop.

Tested on SLC6, Darwin, Xeon Phi, ARMv7 (ODROID-U2), and ARMv7 (Dell, Marvell Armada XP Server Board) targets.
