### PR TITLE
[V00-22-XX] cmsBuild must download a full chain of dependencies

### DIFF
--- a/cmsBuild
+++ b/cmsBuild
@@ -3137,7 +3137,7 @@ def checkPackageInCache(pkg, scheduler):
       if not rpm_db_cache.has_key(baseToolVersion): fetchDependencies = ["install-%s" % baseToolVersion]
   scheduler.parallel("fetch-%s" % pkgName, fetchDependencies, fetchSourcesNew, pkg, scheduler)
   buildActionDependencies = []
-  for p in pkg.origDependencies + pkg.origBuildDependencies:
+  for p in pkg.fullDependencies:
     if not isPackageInstalled(p):
       scheduler.serial("check-%s" % p.pkgName(), [], checkPackageInCache, p, scheduler)
       buildActionDependencies.append("install-%s" % p.pkgName())


### PR DESCRIPTION
Awaits ACK from Shahzad.

Test environment: `IB/CMSSW_7_0_X/stable` and `V00-22-XX`. Add a few empty lines into `clhep.spec` to force rebuild, should fail with the current `V00-22-XX`.
