### PR TITLE
cmsBuild: download full chain of Requires and BuildRequires

### DIFF
--- a/cmsBuild
+++ b/cmsBuild
@@ -3135,7 +3135,7 @@ def checkPackageInCache(pkg, scheduler):
       if not rpm_db_cache.has_key(baseToolVersion): fetchDependencies = ["install-%s" % baseToolVersion]
   scheduler.parallel("fetch-%s" % pkgName, fetchDependencies, fetchSourcesNew, pkg, scheduler)
   buildActionDependencies = []
-  for p in pkg.origDependencies + pkg.origBuildDependencies:
+  for p in pkg.fullDependencies:
     if not isPackageInstalled(p):
       scheduler.serial("check-%s" % p.pkgName(), [], checkPackageInCache, p, scheduler)
       buildActionDependencies.append("install-%s" % p.pkgName())


### PR DESCRIPTION
If we have:

A --(BuildRequires)--> B --(BuildRequires)--> C

We don't need to download C while building A, but it happens to be
that our generated tmpspec-\* will have B and C under BuildRequires.

Thus we must download also C, i.e., a full chain on dependencies
(run-time + build-time) as we don't want to modify tmpsec-\* and
change package checksum.

Signed-off-by: David Abdurachmanov davidlt@cern.ch
