### PR TITLE
cmsBuild: replace ambiguous -i to --info for RPM

### DIFF
--- a/cmsBuild
+++ b/cmsBuild
@@ -2157,7 +2157,7 @@ class Package (object):
         f.write (self.__factory.postProcessSpec (self.spec).replace('%%', '%'))
         f.close ()
         commandPrefix = getCommandPrefix (self.options)
-        evalCommand = "%s rpm -q --specfile %s -i %s" % (commandPrefix,
+        evalCommand = "%s rpm -q --specfile %s --info %s" % (commandPrefix,
                                                       self.tmpspec, self.options.rpmQueryDefines)
         log (evalCommand, DEBUG)
         error, output = getstatusoutput (evalCommand)
@@ -2278,7 +2278,7 @@ class Package (object):
         localSources = []
         localPatches = []
         buildDeps    = []
-        queryCommand = "%s rpm -qi --specfile %s %s 2>/dev/null" % (getCommandPrefix (self.options),
+        queryCommand = "%s rpm -q --info --specfile %s %s 2>/dev/null" % (getCommandPrefix (self.options),
                                                                   self.tmpspec, self.options.rpmQueryDefines)
         regexps = self.__headerMatchingRegexp
         matchers = [(regexps.REQUIRES_REGEXP, deps),


### PR DESCRIPTION
The following change required for newer version of RPM. `rpm' is
now a front-end handling arguments and calling different back-ends.
-i is supported for a couple of back-ends, thus making it ambiguous
to front-end.

Signed-off-by: David Abdurachmanov davidlt@cern.ch
