### PR TITLE
Don't create unnecessary tags in cmsdist

### DIFF
--- a/scripts/prepare-cmsdist
+++ b/scripts/prepare-cmsdist
@@ -47,5 +47,4 @@ pushd CMSDIST
   git commit -m"$MSG" cmssw.spec fwlite.spec cmssw-patch.spec cmssw-patch-tool-conf.spec cmssw-toolfile.spec
   git reset --hard HEAD
   git clean -fxd
-  git tag ${INITIALS}For${CMSSW_ORIG}-${ARCH}
 popd


### PR DESCRIPTION
If the build finished successfully, the tag that is created is named REL/$CMSSW_X_Y_Z/$ARCHITECTURE
There is no need for  ${INITIALS}For${CMSSW_ORIG}-${ARCH} which is exactly the same. 
