### PR TITLE
change compilingProcesses default to be 1

### DIFF
--- a/cmsBuild
+++ b/cmsBuild
@@ -2371,7 +2371,7 @@ def parseOptions():
                       dest="compilingProcesses",
                       metavar="N",
                       help="The number of processes to be used to compile a given package.",
-                      default=0)
+                      default=1)
     parser.add_option("--repository",
                       dest="repository",
                       metavar="NAME",


### PR DESCRIPTION
if cmsBuild is run without --jobs|-j <N> option then it does not define compiling_process which is used by few spec files
