### PR TITLE
rpm_build.sh: move CONFIG_BUILD default settings before --build option

### DIFF
--- a/build_rpm.sh
+++ b/build_rpm.sh
@@ -5,6 +5,17 @@
 PREFIX=/usr/local/bin
 BUILDPROCESSES=2
 
+case ${ARCH} in
+  osx*)
+    # Darwin is not RPM based, explicitly go for guessing the triplet
+    CONFIG_BUILD=guess
+    ;;
+  *)
+    # Assume Linux distro is RPM based and fetch triplet from RPM
+    CONFIG_BUILD=auto
+    ;;
+esac
+
 while [ $# -gt 0 ]
 do
   case "$1" in
@@ -54,17 +65,6 @@ do
     ;;
   esac
 done
-
-case ${ARCH} in
-  osx*)
-    # Darwin is not RPM based, explicitly go for guessing the triplet
-    CONFIG_BUILD=guess
-    ;;
-  *)
-    # Assume Linux distro is RPM based and fetch triplet from RPM
-    CONFIG_BUILD=auto
-    ;;
-esac
 
 set -e
 


### PR DESCRIPTION
This block sets default for `CONFIG_BUILD`, which can be overriden by
`--build <triplet>` option. Currently such option is ignored.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
