### PR TITLE
exception for comp to not use subpackage checksum

### DIFF
--- a/cmsBuild
+++ b/cmsBuild
@@ -1697,11 +1697,12 @@ class SubPackage (object):
         self.srpmfilename   = self.parent.srpmfilename
         self.pkginstroot    = self.parent.pkginstroot
 
-    def dumpSpecFragment(self):
+    def dumpSpecFragment(self, computeSpecChecksum = True):
         importName = 'subpackage-%s.file' % self.subname
         importFilename = join (self.options.cmsdist, importName)
         spec = open (importFilename, 'r').read()
-        spec = re.compile(r'^Summary:.*$', re.M).sub(r'\g<0> SpecChecksum:%s' % self.checksum, spec)
+        if computeSpecChecksum:
+          spec = re.compile(r'^(Summary:.*?)( SpecChecksum:.*|)$', re.M).sub(r'\g<1> SpecChecksum:%s' % self.checksum, spec)
         return spec
 
     def pkgName (self):
@@ -2016,7 +2017,7 @@ class Package (object):
             checksumCalculator.addFile (abspath (filename))
 
         for subpackage in self.subpackages:
-            checksumCalculator.addString( subpackage.dumpSpecFragment() )
+            checksumCalculator.addString( subpackage.dumpSpecFragment(not self.options.repository.split('.')[0] == "comp") )
 
         for pkg in self.dependencies:
             checksumCalculator.addPkg (pkg)


### PR DESCRIPTION
comp repository was not using head of V00-22. So the subpackage in comp repos are not using package checksum for the sub-packages. This change will allow comp to move to head of V00-22 and then V00-24 without rebuilding any existing package. The change is compatible with cms, so no package should be rebuild for cms too.
