### PR TITLE
allow to override USE_COMPILER_VERSION for selected arch

### DIFF
--- a/cmsBuild
+++ b/cmsBuild
@@ -4157,7 +4157,7 @@ if __name__ == "__main__":
                 lines = open(pathname).readlines()
             except IOError, e:
                 fatal("The spec %s does not match the requested architecture %s." % (pathname, opts.architecture))
-            if parseUseCompilerVersionLine(lines) || opts.architecture in USE_COMPILER_VERSION:
+            if parseUseCompilerVersionLine(lines) or opts.architecture in USE_COMPILER_VERSION:
                 (group, name, version) = parseRPMLine(lines, opts)
                 opts.compilerVersion = version.split("-")[0]
             else:

--- a/cmsBuild
+++ b/cmsBuild
@@ -25,6 +25,7 @@ import itertools
 import pickle
 from hashlib import sha256
 from cmsBuild_consts import *
+from cmsdist_config import USE_COMPILER_VERSION
 
 logLevel = 10
 NORMAL = 10
@@ -4156,7 +4157,7 @@ if __name__ == "__main__":
                 lines = open(pathname).readlines()
             except IOError, e:
                 fatal("The spec %s does not match the requested architecture %s." % (pathname, opts.architecture))
-            if parseUseCompilerVersionLine(lines):
+            if parseUseCompilerVersionLine(lines) || opts.architecture in USE_COMPILER_VERSION:
                 (group, name, version) = parseRPMLine(lines, opts)
                 opts.compilerVersion = version.split("-")[0]
             else:

--- a/cmsdist_config.py
+++ b/cmsdist_config.py
@@ -1,0 +1,1 @@
+USE_COMPILER_VERSION = [ "slc7_aarch64_gcc820", "slc7_ppc64le_gcc820" ]


### PR DESCRIPTION
This avoid re-build every thing for existing arch but for new archs it can correctly use the gcc version from gcc.spec file.