### PR TITLE
Monitor functions for rpmbuild commands

### DIFF
--- a/cmsBuild
+++ b/cmsBuild
@@ -9,7 +9,7 @@ from getpass import getuser
 from tempfile import mkdtemp, mkstemp, NamedTemporaryFile
 from commands import getstatusoutput
 from urllib2 import urlopen, URLError
-from time import strftime, time
+from time import strftime, time, sleep
 import sys
 import copy
 from ConfigParser import ConfigParser
@@ -26,10 +26,8 @@ import pickle
 from hashlib import sha256
 from cmsBuild_consts import *
 from cmsdist_config import USE_COMPILER_VERSION
-import subprocess
-import psutil
-from threading import Thread
-from json import dump as jsn_dmp
+try: from monitor_build import run_monitor_on_command
+except: run_monitor_on_command=None
 
 logLevel = 10
 NORMAL = 10
@@ -2814,7 +2812,7 @@ def parseOptions():
                                     help="CSV of package(s) which should not be taken from reference repostiroy.")
     advancedBuildOptions.add_option("--new-scheduler", dest="newScheduler", action="store_true",
                                     default=False, help="Use the new scheduler to install / build packages")
-    advancedBuildOptions.add_option("--with-rpmbuild-monitor", dest="enableMonitor", action="store_true",
+    advancedBuildOptions.add_option("--monitor", dest="enableMonitor", action="store_true",
                                     default=False, help="Enable rpmbuild jobs stats monitoring")
     # FIXME: change option to --no-deprecate and do the deprecation
     #        automatically by default.
@@ -2885,6 +2883,9 @@ def parseOptions():
     parser.add_option_group(uploadGroup)
     parser.add_option_group(debugGroup)
     opts, args = parser.parse_args(None, None)
+    if opts.enableMonitor and not run_monitor_on_command:
+        opts.enableMonitor = False
+        log ("Warning: Disabling monitoring. Failed to import run_monitor_on_command from monitor_build.")
 
     if opts.weekly:
         n = int(((time()/86400)+4)/7)%2
@@ -3262,7 +3263,7 @@ def buildPackage(pkg, scheduler):
                       " TMPDIR=%(tmpdir)s %(prefix)s rpmbuild %(nodeps)s --buildroot %(buildRoot)s -ba --define '_topdir %(topdir)s'" \
                       " %(makeprocesses)s %(ignoreCompileErrors)s %(extraRpmDefines)s" \
                       " %(specdir)s/spec >%(builddir)s/log 2>&1" % optionsDict
-
+    monitor_job = opts.enableMonitor
     if pkg.pkgExtraRepo:
         rep = pkg.pkgExtraRepo
         exrpm=format("%(tmpdir)s/repo/%(rep)s/%(arch)s/var/cmspkg/rpms/%(rpmname)s",
@@ -3293,13 +3294,14 @@ def buildPackage(pkg, scheduler):
                 depOK = False
                 break
         if depOK:
+            monitor_job = False
             rpmbuildCommand ="mv %s %s" % (exrpm, uniqueRpmFilename)
 
     rpmbuildCommand = rpmbuildCommand.strip()
     scheduler.log(rpmbuildCommand)
 
-    if opts.enableMonitor:
-        error, output = run_monitor_on_command(rpmbuildCommand, pkg.name, opts.architecture)
+    if monitor_job:
+        error, output = run_monitor_on_command(rpmbuildCommand, "%s/%s.json" % (pkg.builddir, pkg.name))
     else:
         error, output = getstatusoutput(rpmbuildCommand)
 
@@ -3311,10 +3313,10 @@ def buildPackage(pkg, scheduler):
             pkg.name, logfile, "".join(logLines[-20:]))
     if opts.deleteBuildDirectory:
       optionsDict["pkgname"] = pkg.name
-      optionsDict["logs"] = "log %s" % pkg.buildLogsToKeep
+      optionsDict["logs"] = "log %s %s" % (pkg.buildLogsToKeep , "%s.json" % pkg.name if monitor_job else "")
       cmd = "rm -rf %(tmpdir)s/%(pkgname)s-logs && " \
             "mkdir %(tmpdir)s/%(pkgname)s-logs && " \
-            "for log in %(logs)s ; do mv %(builddir)s/$log %(tmpdir)s/%(pkgname)s-logs/ ; done ; " \
+            "for log in %(logs)s ; do mv %(builddir)s/$log %(tmpdir)s/%(pkgname)s-logs/ || true; done ; " \
             "rm -rf %(builddir)s && " \
             "mv %(tmpdir)s/%(pkgname)s-logs %(builddir)s" % optionsDict
       scheduler.log("Build logs cleanup %s" % pkg.name)
@@ -3381,9 +3383,6 @@ def installPackage(pkg, scheduler):
     f.close()
     if pkg_error: raise RpmBuildFailed(pkg)
     scheduler.reschedule()
-
-
-from time import sleep
 
 
 class ActionFactory(object):
@@ -4102,67 +4101,6 @@ def checkOptionsLocalSource(opts):
         elif source is "Source0":
             sourceOptionDict[pkg]["Source"] = source_path
         opts.localSources = sourceOptionDict
-
-# bring the monitor script from cms-bot as functions
-# TODO make it work without shell=True as the monitor script is currently working
-
-def update_monitor_stats(proc):
-    stats = {"rss": 0, "vms": 0, "shared": 0, "data": 0, "uss": 0, "pss": 0, "num_fds": 0, "num_threads": 0, "processes": 0, "cpu": 0}
-    children = proc.children(recursive=True)
-    clds = len(children)
-    if clds==0: return stats
-    stats['processes'] = clds
-    for cld in children:
-        try:
-            mem   = cld.memory_full_info()
-            fds   = cld.num_fds()
-            thrds = cld.num_threads()
-            cld.cpu_percent(interval=None)
-            sleep(0.1)
-            cpu   = int(cld.cpu_percent(interval=None))
-            stats['num_fds'] += fds
-            stats['num_threads'] += thrds
-            stats['cpu'] += cpu
-            for a in ["rss", "vms", "shared", "data", "uss", "pss"]: stats[a]+=getattr(mem,a)
-        except:pass
-    return stats
-
-def monitor_stats(stop, p_id, st_file_name = None):
-
-    stime = int(time())
-    p = psutil.Process(p_id)
-    stats_f_name = st_file_name
-    if not st_file_name:
-        stats_f_name = stime
-    data = []
-    while not stop():
-        try:
-            stats = update_monitor_stats(p)
-            if stats['processes']==0: break
-            stats['time'] = int(time()-stime)
-            data.append(stats)
-        except: pass
-        sleep_time = 1.0 - stats['processes']*0.1
-        if sleep_time > 0.1: sleep(sleep_time)
-    with open("wf_stats-%s.json" % stats_f_name, "w") as sf:
-        jsn_dmp(data, sf)
-    return
-
-def run_monitor_on_command(command_to_monitor=None, package_name='', architecture=''):
-
-    stats_file_name = package_name+"_"+architecture
-    if stats_file_name is '_': stats_file_name = None
-    stop_monitoring = False
-
-    p = subprocess.Popen(command_to_monitor, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds= True)
-    sleep(1)
-    mon_thd = Thread(target=monitor_stats, args=(lambda: stop_monitoring, p.pid, stats_file_name,))
-    mon_thd.start()
-    stout, sterr = p.communicate() # this blocks until the process is finished
-    stop_monitoring = True
-    mon_thd.join()
-
-    return sterr, stout
 
 if __name__ == "__main__":
     # Stop processing if SCRAM runtime env is set to avoid picking up

--- a/cmsBuild
+++ b/cmsBuild
@@ -26,6 +26,9 @@ import pickle
 from hashlib import sha256
 from cmsBuild_consts import *
 from cmsdist_config import USE_COMPILER_VERSION
+import subprocess
+import psutil
+from threading import Thread
 
 logLevel = 10
 NORMAL = 10
@@ -2810,6 +2813,8 @@ def parseOptions():
                                     help="CSV of package(s) which should not be taken from reference repostiroy.")
     advancedBuildOptions.add_option("--new-scheduler", dest="newScheduler", action="store_true",
                                     default=False, help="Use the new scheduler to install / build packages")
+    advancedBuildOptions.add_option("--with-rpmbuild-monitor", dest="enableMonitor", action="store_true",
+                                    default=False, help="Enable rpmbuild jobs stats monitoring")
     # FIXME: change option to --no-deprecate and do the deprecation
     #        automatically by default.
     # parser.add_option ("--deprecate-local",
@@ -3256,6 +3261,7 @@ def buildPackage(pkg, scheduler):
                       " TMPDIR=%(tmpdir)s %(prefix)s rpmbuild %(nodeps)s --buildroot %(buildRoot)s -ba --define '_topdir %(topdir)s'" \
                       " %(makeprocesses)s %(ignoreCompileErrors)s %(extraRpmDefines)s" \
                       " %(specdir)s/spec >%(builddir)s/log 2>&1" % optionsDict
+
     if pkg.pkgExtraRepo:
         rep = pkg.pkgExtraRepo
         exrpm=format("%(tmpdir)s/repo/%(rep)s/%(arch)s/var/cmspkg/rpms/%(rpmname)s",
@@ -3290,7 +3296,12 @@ def buildPackage(pkg, scheduler):
 
     rpmbuildCommand = rpmbuildCommand.strip()
     scheduler.log(rpmbuildCommand)
-    error, output = getstatusoutput(rpmbuildCommand)
+
+    if opts.enableMonitor:
+        error, output = run_monitor_on_command(rpmbuildCommand, pkg.name, opts.architecture)
+    else:
+        error, output = getstatusoutput(rpmbuildCommand)
+
     if error:
         if not exists(logfile):
             return "Error happened before any log output.\n%s" % output
@@ -4091,6 +4102,69 @@ def checkOptionsLocalSource(opts):
             sourceOptionDict[pkg]["Source"] = source_path
         opts.localSources = sourceOptionDict
 
+# bring the monitor script from cms-bot as functions
+# TODO make it work without shell=True as the monitor script is currently working
+
+def update_monitor_stats(proc):
+    stats = {"rss": 0, "vms": 0, "shared": 0, "data": 0, "uss": 0, "pss": 0, "num_fds": 0, "num_threads": 0, "processes": 0, "cpu": 0}
+    children = proc.children(recursive=True)
+    clds = len(children)
+    if clds==0: return stats
+    stats['processes'] = clds
+    for cld in children:
+        try:
+            mem   = cld.memory_full_info()
+            fds   = cld.num_fds()
+            thrds = cld.num_threads()
+            cld.cpu_percent(interval=None)
+            sleep(0.1)
+            cpu   = int(cld.cpu_percent(interval=None))
+            stats['num_fds'] += fds
+            stats['num_threads'] += thrds
+            stats['cpu'] += cpu
+            for a in ["rss", "vms", "shared", "data", "uss", "pss"]: stats[a]+=getattr(mem,a)
+        except:pass
+    return stats
+
+def monitor_stats(stop, p_id, st_file_name = None):
+
+    stime = int(time())
+    p = psutil.Process(p_id)
+    stats_f_name = st_file_name
+    if not st_file_name:
+        stats_f_name = stime
+    data = []
+    while not stop():
+        try:
+            stats = update_monitor_stats(p)
+            if stats['processes']==0: break
+            stats['time'] = int(time()-stime)
+            data.append(stats)
+        except: pass
+        sleep_time = 1.0 - stats['processes']*0.1
+        if sleep_time > 0.1: sleep(sleep_time)
+    from json import dump
+
+    stat_file =open("wf_stats-%s.json" % stats_f_name,"w")
+    dump(data, stat_file)
+    stat_file.close()
+    return
+
+def run_monitor_on_command(command_to_monitor=None, package_name='', architecture=''):
+
+    stats_file_name = package_name+"_"+architecture
+    if stats_file_name is '_': stats_file_name = None
+    stop_monitoring = False
+
+    p = subprocess.Popen(command_to_monitor, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds= True)
+    sleep(1)
+    mon_thd = Thread(target=monitor_stats, args=(lambda: stop_monitoring, p.pid, stats_file_name,))
+    mon_thd.start()
+    stout, sterr = p.communicate() # this blocks until the process is finished
+    stop_monitoring = True
+    mon_thd.join()
+
+    return sterr, stout
 
 if __name__ == "__main__":
     # Stop processing if SCRAM runtime env is set to avoid picking up

--- a/cmsBuild
+++ b/cmsBuild
@@ -29,6 +29,7 @@ from cmsdist_config import USE_COMPILER_VERSION
 import subprocess
 import psutil
 from threading import Thread
+from json import dump as jsn_dmp
 
 logLevel = 10
 NORMAL = 10
@@ -4143,11 +4144,8 @@ def monitor_stats(stop, p_id, st_file_name = None):
         except: pass
         sleep_time = 1.0 - stats['processes']*0.1
         if sleep_time > 0.1: sleep(sleep_time)
-    from json import dump
-
-    stat_file =open("wf_stats-%s.json" % stats_f_name,"w")
-    dump(data, stat_file)
-    stat_file.close()
+    with open("wf_stats-%s.json" % stats_f_name, "w") as sf:
+        jsn_dmp(data, sf)
     return
 
 def run_monitor_on_command(command_to_monitor=None, package_name='', architecture=''):

--- a/monitor_build.py
+++ b/monitor_build.py
@@ -1,0 +1,49 @@
+import subprocess
+from threading import Thread
+import psutil
+from json import dump as json_dump
+from time import time, sleep
+
+def update_monitor_stats(proc):
+    stats = {"rss": 0, "vms": 0, "shared": 0, "data": 0, "uss": 0, "pss": 0, "num_fds": 0, "num_threads": 0, "processes": 0, "cpu": 0}
+    children = proc.children(recursive=True)
+    clds = len(children)
+    if clds==0: return stats
+    stats['processes'] = clds
+    for cld in children:
+        try:
+            cld.cpu_percent(interval=None)
+            sleep(0.1)
+            stats['cpu'] += int(cld.cpu_percent(interval=None))
+            stats['num_fds'] += cld.num_fds()
+            stats['num_threads'] += cld.num_threads()
+            mem = None
+            try:
+                mem   = cld.memory_full_info()
+                for a in ["uss", "pss"]: stats[a]+=getattr(mem,a)
+            except:
+                mem   = cld.memory_info_ex()
+            for a in ["rss", "vms", "shared", "data"]: stats[a]+=getattr(mem,a)
+        except: pass
+    return stats
+
+def monitor_stats(p_id, stats_file_name):
+    stime = int(time())
+    p = psutil.Process(p_id)
+    data = []
+    while p.is_running():
+        stats = update_monitor_stats(p)
+        stats['time'] = int(time()-stime)
+        data.append(stats)
+        sleep(1.0)
+    with open(stats_file_name, "w") as sf:
+        json_dump(data, sf)
+    return
+
+def run_monitor_on_command(command_to_monitor, stats_file_name):
+    p = subprocess.Popen(command_to_monitor, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds= True)
+    mon_thd = Thread(target=monitor_stats, args=(p.pid, stats_file_name,))
+    mon_thd.start()
+    stout, sterr = p.communicate() # this blocks until the process is finished
+    mon_thd.join() # wait for monitoring thread to write its output
+    return p.returncode, stout


### PR DESCRIPTION
Starts a process for each rpmbuild thread, where the process metrics are sampled with the update_monitor_stats function. 