### PR TITLE
various improvements

### DIFF
--- a/cmsBuild
+++ b/cmsBuild
@@ -32,6 +32,7 @@ from cmsdist_config import USE_COMPILER_VERSION
 try: from monitor_build import run_monitor_on_command
 except: run_monitor_on_command=None
 
+urlRe = re.compile(".*:.*/.*")
 logLevel = 10
 NORMAL = 10
 DEBUG = 20
@@ -47,7 +48,9 @@ PKGFactory = None
 SystemCompilerVersion = {}
 BlackListReferencePkgs = []
 reference_rpm_db_cache = {}
-
+rpm_db_cache = {}
+cmspkg_upload_cache = {"": []}
+rpm_upload_cache = {}
 removeInitialSpace = re.compile("^[ ]*", re.M)
 cmsBuildFilename = abspath(__file__)
 
@@ -120,8 +123,34 @@ def detectCompilerVersion(compilerName):
     return SystemCompilerVersion[compilerName]
 
 
-rpm_db_cache = {}
-
+def cmspkg_showpkgs(packages):
+    pkgs = ""
+    pkgs1 = ""
+    for pkg in packages:
+        pname = pkg.pkgName()
+        cmspkg_upload_cache[pname] = []
+        rpm_upload_cache[pname] = []
+        pkgs = pkgs+" "+pname
+        pkgs1 = pkgs1+" "+pname+"-1-"+pkg.pkgRevision
+    err, output = getstatusoutput("%s showpkg %s" % (CMSPKG_CMD, pkgs))
+    if err: return (err, output)
+    data = output.split("\n")
+    pkg = ""
+    for l in data:
+        if " - CMS Experiment package" in l:
+            pkg = l.split(" ")[0]
+        cmspkg_upload_cache[pkg].append(l)
+    err, output = getstatusoutput("%s ; rpm -q %s" % (rpmEnvironmentScript, pkgs1))
+    if err: return (err, output)
+    for l in output.split("\n"):
+        if '-1-' in l:
+            cmspkg_upload_cache[l.split('-1-')[0]].append(l)
+    err, output = getstatusoutput("%s ; rpm -q %s" % (rpmEnvironmentScript, pkgs))
+    if err: return (err, output)
+    for l in output.split("\n"):
+        if '-1-' in l:
+            rpm_upload_cache[l.split('-1-')[0]].append(l)
+    return (err, "")
 
 #################################################################
 # Utilities functions for installing packages from ref repository#
@@ -775,7 +804,7 @@ def download(source, dest, options, pkg=None):
         getLocalSources(pkg, source_name, downloadDir, filename)
 
     if exists(realFile):
-        if not exists(join(dest, filename)):
+        if dest and not exists(join(dest, filename)):
             symlink(realFile, join(dest, filename))
         return True
     srepos = [options.repository]
@@ -801,7 +830,7 @@ def download(source, dest, options, pkg=None):
         f = open(join(downloadDir, "url"), 'w')
         f.write("%s\n" % source)
         f.close()
-        if exists(realFile) and not exists(join(dest, filename)):
+        if dest and exists(realFile) and not exists(join(dest, filename)):
             symlink(realFile, join(dest, filename))
     return success
 
@@ -1536,7 +1565,7 @@ class BuilderAction(object):
         """ Returns True if the action should been executed, False if not.
         """
         # If we already have checked this, do not run the check again.
-        if self.__cachedRun:
+        if self.__cachedRun is not None:
             return self.__cachedRun
         self.__safeRecursion += 1
         if self.__safeRecursion > 100:
@@ -1677,12 +1706,8 @@ class InstallFromLocalArea(BuilderAction):
         if not self.dryRun():
             return False
         pkgName = self.pkg.pkgName()
-        error, output = getstatusoutput("%s ; rpm -q %s" % (rpmEnvironmentScript, pkgName))
-        # Not all the rpm commands set the error correctly.
-        if error or "error:" in output:
-            return False
+        lines = rpm_upload_cache[pkgName]
         filesExists = exists(self.cachedRpmName) and exists(self.officialRpmName)
-        lines = output.strip("\n").split("\n")
         tooManyLines = len(lines) != 1
         if tooManyLines and filesExists:
             return False
@@ -1719,17 +1744,10 @@ class InstallFromServer(BuilderAction):
         pkgName = self.pkg.pkgName()
         pkgInfo = PkgInfo(self.pkg)
         pkgRealName = pkgInfo.id()
+        pkgRev = self.pkg.pkgRevision
         pkgsWithSameHash = [p for (p, h) in tags_cache.cache.items() if
                             (h == pkgInfo.checksum) and p.startswith(pkgRealName) and (pkgName != p)]
-
-        # If a file exists on server we return True
-        cmsPkgCmd = CMSPKG_CMD
-        rpmenv = rpmEnvironmentScript
-        pkgRev = self.pkg.pkgRevision
-        searchCommand = """%(cmsPkgCmd)s showpkg %(pkgName)s; %(rpmenv)s ; rpm -q %(pkgName)s-1-%(pkgRev)s""" % locals()
-        error, output = getstatusoutput(searchCommand)
-        self.output = output.split("\n")
-        if error: return False
+        self.output = cmspkg_upload_cache[pkgName]
 
         def evalExistsOnServer():
             for line in self.output[2:]:
@@ -3075,18 +3093,17 @@ def fetchLocal(pkg, sourceFilename):
         return (sourceFilename, False)
 
 
-def fetchSources(pkg, scheduler):
-    scheduler.log("Fetching sources for %s" % pkg.name)
+def fetchSources(pkg, scheduler, url=None):
     sourcedir = pkg.sourcedir
-    downloadables = pkg.sources + pkg.patches
-    if not downloadables:
-        scheduler.log("No sources to be downloaded found for packages %s." % pkg.name)
-        return
-    urlRe = re.compile(".*:.*/.*")
-
-    # No need to create the download directory
-    # not to dump the cmsos, because it was already
-    # done.
+    downloadables = []
+    if url:
+      downloadables = [url]
+      sourcedir = None
+    else:
+      downloadables = pkg.sources + pkg.patches
+      scheduler.log("Fetching sources for %s" % pkg.name)
+      if not downloadables:
+          return
     for url in downloadables:
         if urlRe.match(url):
             try:
@@ -3097,7 +3114,9 @@ def fetchSources(pkg, scheduler):
             output, success = fetchLocal(pkg, url)
         if not success:
             return "Unable to download %s" % url
-        scheduler.log("Done fetching %s" % url)
+        if sourcedir:
+            scheduler.log("Done fetching %s" % url)
+    return
 
 
 def checkIfOnServer(pkg):
@@ -3552,7 +3571,7 @@ class BuildChecker(object):
             if action.dryRun() and action.producesStuffToUpload():
                 log("Action '%s' for package '%s' produces something to be uploaded." % (action.actionName,
                                                                                          action.pkg.pkgName()), DEBUG)
-                result = result or True
+                result = True
         return result
 
 
@@ -3595,15 +3614,22 @@ def checkPackageInCache(pkg, scheduler):
         dep_pkg = [p.pkgName() for p in getPackages(pkg.fullDependencies) if p.name == d][0]
         if (not dep_pkg in rpm_db_cache) and (not "install-"+dep_pkg in fetchDependencies):
             fetchDependencies += ["install-" + dep_pkg]
+    buildActionDependencies = []
     pkgSources = pkg.sources + pkg.patches
     if pkgSources:
-        scheduler.parallel("fetch-%s" % pkgName, fetchDependencies, fetchSources, pkg, scheduler)
-    buildActionDependencies = []
+        urls = [url for url in pkgSources if urlRe.match(url)]
+        srcDeps = fetchDependencies
+        if urls:
+            srcDeps = []
+            for url in urls:
+                srcDeps.append("download-%s" % getUrlChecksum(url))
+                scheduler.parallel(srcDeps[-1], fetchDependencies, fetchSources, pkg, scheduler, url)
+        scheduler.parallel("fetch-%s" % pkgName, srcDeps, fetchSources, pkg, scheduler)
+        buildActionDependencies.append("fetch-%s" % pkgName)
     for p in getPackages(list(set(pkg.origDependencies+pkg.origBuildDependencies+pkg.installDependencies+pkg.uploadDependencies))):
         if not isPackageInstalled(p):
             scheduler.serial("check-%s" % p.pkgName(), [], checkPackageInCache, p, scheduler)
             buildActionDependencies.append("install-%s" % p.pkgName())
-    if pkgSources: buildActionDependencies.append("fetch-%s" % pkgName)
     installActionDependencies = ["build-%s" % pkgName]
     scheduler.log("Dependencies for %s: %s" % (pkgName, buildActionDependencies))
     scheduler.parallel("build-%s" % pkgName, buildActionDependencies, buildPackage, pkg, scheduler)
@@ -3956,17 +3982,28 @@ def upload(opts, args, factory):
         return statusAndLog(True, "Nothing needs to be uploaded")
     cmsplatf = fullPackageList[0].cmsplatf
     uploadablePackages = []
+    err, out = cmspkg_showpkgs(fullPackageList)
+    logAndDieOnError(err, "Error running local rpm query commands.\n"+out)
+    deprecatePkgs = []
     for pkg in fullPackageList:
         checker = BuildChecker(pkg)
         if not checker.checkConsistency():
-            statusAndLog(False, "ERROR: Build area not consistent. Not uploading.")
-            executeScript(opts, deprecateLocalCommand(opts, fullPackageList))
-            return False
+            deprecatePkgs.append(pkg)
+            continue
         if not checker.checkIfUploadable():
             statusAndLog(True, "Nothing needs to be uploaded for %(name)s.",
                          name=pkg.pkgName())
             continue
         uploadablePackages.append(pkg)
+    if deprecatePkgs:
+        pkg2deprecate = [p.name for p in deprecatePkgs]
+        for pkg in deprecatePkgs:
+            for d in [p.name for p in fullPackageList if pkg.name in p.fullDependencies]:
+                if d not in pkg2deprecate:
+                    pkg2deprecate.append(d)
+        statusAndLog(False, "ERROR: Build area not consistent. Not uploading.")
+        executeScript(opts, deprecateLocalCommand(opts, getPackages(pkg2deprecate)))
+        return False
     fullPackageList = uploadablePackages
     if not fullPackageList:
         return statusAndLog(True, "Nothing needs to be uploaded")

--- a/scheduler.py
+++ b/scheduler.py
@@ -45,6 +45,8 @@ class Scheduler(object):
   def __init__(self, parallelThreads, logDelegate=None):
     self.workersQueue = Queue()
     self.resultsQueue = Queue()
+    self.notifyQueue = Queue()
+    self.rescheduleParallel = False
     self.jobs = {}
     self.pendingJobs = []
     self.runningJobs = []
@@ -69,13 +71,13 @@ class Scheduler(object):
       t = Thread(target=self.__createWorker())
       t.daemon = True
       t.start()
-    
-    self.notifyMaster(self.__rescheduleParallel)
+
+    self.__doRescheduleParallel()
     # Wait until all the workers are done.
     while self.parallelThreads:
       try:
+        self.__doNotifications()
         who, item = self.resultsQueue.get()
-        #print who, item
         item[0](*item[1:])
         sleep(0.1)
       except KeyboardInterrupt:
@@ -83,11 +85,13 @@ class Scheduler(object):
         while self.workersQueue.full():
           self.workersQueue.get(False)
         self.shout(self.quit)
-    
+
     # Prune the queue.
+    self.__doNotifications ()
     while self.resultsQueue.full():
       item = self.resultsQueue.get() 
       item[0](*item[1:])
+    self.__doNotifications ()
     return
 
   # Create a worker.
@@ -103,14 +107,21 @@ class Scheduler(object):
           result = s.getvalue()
           
         if type(result) == _SchedulerQuitCommand:
-          self.notifyMaster(self.__releaseWorker)
+          self.notifyTaskMaster(self.__releaseWorker)
           return
         self.log(str(item) + " done")
         self.notifyMaster(self.__updateJobStatus, taskId, result)
         self.notifyMaster(self.__rescheduleParallel)
-        # Only in 2.5: self.workersQueue.task_done()
     return worker
-  
+
+  def __doNotifications(self):
+    self.rescheduleParallel = False
+    while self.notifyQueue.qsize():
+      who, item = self.notifyQueue.get()
+      item[0](*item[1:])
+    if self.rescheduleParallel:
+       self.__doRescheduleParallel()
+
   def __releaseWorker(self):
     self.parallelThreads -= 1
 
@@ -122,6 +133,9 @@ class Scheduler(object):
 
   # Does the rescheduling of tasks. Derived class should call it.
   def __rescheduleParallel(self):
+    self.rescheduleParallel = True
+
+  def __doRescheduleParallel(self):
     parallelJobs = [j for j in self.pendingJobs if self.jobs[j]["scheduler"] == "parallel"]
     # First of all clean up the pending parallel jobs from all those
     # which have broken dependencies.
@@ -136,7 +150,7 @@ class Scheduler(object):
     # since they might queue more parallel payloads.
     if not self.pendingJobs:
       self.shout(self.quit)
-      self.notifyMaster(self.quit)
+      self.notifyTaskMaster(self.quit)
       return
 
     # Otherwise do another round of scheduling of all the tasks. In this
@@ -173,8 +187,11 @@ class Scheduler(object):
       self.__scheduleParallel("quit-" + str(x), commandSpec)
 
   # Helper to enqueu replies to the master thread.
-  def notifyMaster(self, *commandSpec):
+  def notifyTaskMaster(self, *commandSpec):
     self.resultsQueue.put((threading.currentThread(), commandSpec))
+
+  def notifyMaster(self, *commandSpec):
+    self.notifyQueue.put((threading.currentThread(), commandSpec))
 
   def forceDone(self, taskId):
     if taskId in self.doneJobs: return


### PR DESCRIPTION
**cmsBuild**:
- Improve upload logic: 
  - Use cache reulsts instead of running every commands 4 times
  - Run cmspkg and rpm for all locally build packages instead of running individual commands for every package separately.
  - On finding the conflicts (e.g. a local built package was already uploaded by someone else), deprecate only the conflicting packages and packages depend on these.
- Improve Source download:
  - Add separate download task for each URL
  - Allow parallel doenload of sources
  - Avoid duplicate downloads e.g. is a source is used by multiple packages

**scheduler.py**:
  - Separate queues for notifications and tasks. This improved the ruuning of parallel tasks
  - Run rescheduling of parallel tasks only once after processing all the notifications
  
