### PR TITLE
Build externals in parallel - add resource class and scheduler changes

### DIFF
--- a/cmsBuild
+++ b/cmsBuild
@@ -2878,6 +2878,13 @@ def parseOptions():
     advancedBuildOptions.add_option("--ldps", "--log-deps",
                                     dest="depsLog", action="store_true",
                                     default=False, help="store json formatted log of dependencies in workDir/WEB/arch")
+    # give the stats to the script instad of making it running a script from here to do it
+    advancedBuildOptions.add_option("--estats", "--externals-stats",
+                                    dest="externalsStatsFile",
+                                    default=None,
+                                    metavar="FILENAME",
+                                    help="JSON file with externals compilation metrics, from elastic search or default from github")
+
     # FIXME: change option to --no-deprecate and do the deprecation
     #        automatically by default.
     # parser.add_option ("--deprecate-local",
@@ -3631,9 +3638,9 @@ def checkPackageInCache(pkg, scheduler):
 
 
 # New version using the new scheduler.
-def buildSpecs(topLevelPackages):
+def buildSpecs(topLevelPackages, buildStats=None):
     from scheduler import Scheduler
-    scheduler = Scheduler(topLevelPackages[0].options.workersPoolSize, log)
+    scheduler = Scheduler(topLevelPackages[0].options.workersPoolSize, log, buildStats)
     for pkg in topLevelPackages:
         if not isPackageInstalled(pkg):
             scheduler.serial("check-%s" % pkg.pkgName(), [], checkPackageInCache, pkg, scheduler)
@@ -3715,8 +3722,13 @@ def build(opts, args, factory):
     if opts.pretend:
         log("Option --pretend specified. Not building.")
         return
-    buildSpecs(packages)
-
+    build_stats = None
+    if opts.externalsStatsFile and os.path.exists(opts.externalsStatsFile):
+        # read the stats from a json file, also the machine specifics are there
+        from json import load
+        with open(opts.externalsStatsFile) as f:
+            build_stats = load(f)
+    buildSpecs(packages, build_stats)
 
 def isPackageInstalled(pkg):
     if pkg.options.bootstrap:

--- a/rmanager.py
+++ b/rmanager.py
@@ -1,12 +1,12 @@
 class ResourceManager(object):
     def __init__(self, ESstats, cpu_percent_usage, memory_percent_usage, njobs):
-        self.machineResources = { "total": {"cpu_75": cpu_percent_usage*int(ESstats["MachineCPUCount"]), 
+        self.machineResources = { "total": {"cpu_90": cpu_percent_usage*int(ESstats["MachineCPUCount"]),
                                             "rss_75" : memory_percent_usage*int(ESstats["MachineMemoryGB"])*10737418 },
-                                  "available": {"cpu_75": cpu_percent_usage*int(ESstats["MachineCPUCount"]),
+                                  "available": {"cpu_90": cpu_percent_usage*int(ESstats["MachineCPUCount"]),
                                             "rss_75" : memory_percent_usage*int(ESstats["MachineMemoryGB"])*10737418 } }
         self.externalsStats = ESstats["externals"]# this should be get before running pkgtools
         self.resourcesAllocatedForExternals = {} # resources that were alocated for given externals, say root -> "root": {"rss":"", cpu:""}
-        self.jobsOrderMetric = "cpu_75" # default to cpu
+        self.priorityList = ["time", "cpu_90"] # can be any list from the stat keys
         self.missingExternalsStrategy = None # runFirst, runLast
     
     def allocResourcesForExternals(self, externalsList=[]): # return ordered list for externals that can be started
@@ -17,22 +17,23 @@ class ResourceManager(object):
             short_name = e.split('+')[1]
             ext_name_to_fullname_dict[short_name]=e
         externalsList_shortNames = ext_name_to_fullname_dict.keys()
-        # if record for an external is not available, allocate it 1/4th of the resources and run it first
+        # If record for an external is not available, allocate it half the cpu and 1/6th RAM from the resources to run it
         # OR allocate all resources for each missing external, forcing them to build last one by one.
         externals_to_run = []
         for ext in externalsList_shortNames:
             if ext not in self.externalsStats:
                 # external is not found, this should happen only for new externals. get the first element whichever it is and change its properties
-                self.externalsStats[ext] = [{"name":ext, "cpu_75":self.machineResources["total"]["cpu_75"]/4,"rss_75":self.machineResources["total"]["rss_75"]/10 }]
-            externals_to_run.append(self.externalsStats[ext][0])        
+                print 'external: ', ext, 'not found, create entry for it'
+                self.externalsStats[ext] = [{"name":ext, "cpu_90":self.machineResources["total"]["cpu_90"]/2,"rss_75":self.machineResources["total"]["rss_75"]/6,"time":1800 }]
+            externals_to_run.append(self.externalsStats[ext][0])
         # first order them by metric and then run over to alloc resources
-        externalsList_sorted = [ext for ext in sorted(externals_to_run, key=lambda x: x[self.jobsOrderMetric], reverse=True)]
+        externalsList_sorted = [ext for ext in sorted(externals_to_run, key=lambda x: tuple(x[k] for k in self.priorityList), reverse=True)]
 
         externals_to_run = []
         for ex_stats in externalsList_sorted:
-            if (ex_stats["cpu_75"]<=self.machineResources["available"]["cpu_75"] and ex_stats["rss_75"]<=self.machineResources["available"]["rss_75"]):
+            if (ex_stats["cpu_90"]<=self.machineResources["available"]["cpu_90"] and ex_stats["rss_75"]<=self.machineResources["available"]["rss_75"]):
                 self.resourcesAllocatedForExternals[ex_stats["name"]] = {}
-                for prm in ["rss_75", "cpu_75"]:
+                for prm in ["rss_75", "cpu_90"]:
                     self.machineResources["available"][prm] -= ex_stats[prm]
                     self.resourcesAllocatedForExternals[ex_stats["name"]][prm] = ex_stats[prm]
                 externals_to_run.append(ext_name_to_fullname_dict[ex_stats["name"]]) # this gets the full names
@@ -41,6 +42,6 @@ class ResourceManager(object):
     def releaseResourcesForExternal(self, external): # external name
         # get the external name only
         external = external.split('+')[1]
-        for prm in ["rss_75", "cpu_75"]:
+        for prm in ["rss_75", "cpu_90"]:
             self.machineResources["available"][prm] += self.resourcesAllocatedForExternals[external][prm]
         del self.resourcesAllocatedForExternals[external]

--- a/rmanager.py
+++ b/rmanager.py
@@ -1,0 +1,46 @@
+class ResourceManager(object):
+    def __init__(self, ESstats, cpu_percent_usage, memory_percent_usage, njobs):
+        self.machineResources = { "total": {"cpu_75": cpu_percent_usage*int(ESstats["MachineCPUCount"]), 
+                                            "rss_75" : memory_percent_usage*int(ESstats["MachineMemoryGB"])*10737418 },
+                                  "available": {"cpu_75": cpu_percent_usage*int(ESstats["MachineCPUCount"]),
+                                            "rss_75" : memory_percent_usage*int(ESstats["MachineMemoryGB"])*10737418 } }
+        self.externalsStats = ESstats["externals"]# this should be get before running pkgtools
+        self.resourcesAllocatedForExternals = {} # resources that were alocated for given externals, say root -> "root": {"rss":"", cpu:""}
+        self.jobsOrderMetric = "cpu_75" # default to cpu
+        self.missingExternalsStrategy = None # runFirst, runLast
+    
+    def allocResourcesForExternals(self, externalsList=[]): # return ordered list for externals that can be started
+        # first, strip the names from build-*++version and make a tmp name to full name dict.
+        # toolfiles should not arrive here, but will also work if they do
+        ext_name_to_fullname_dict = {}
+        for e in externalsList:
+            short_name = e.split('+')[1]
+            ext_name_to_fullname_dict[short_name]=e
+        externalsList_shortNames = ext_name_to_fullname_dict.keys()
+        # if record for an external is not available, allocate it 1/4th of the resources and run it first
+        # OR allocate all resources for each missing external, forcing them to build last one by one.
+        externals_to_run = []
+        for ext in externalsList_shortNames:
+            if ext not in self.externalsStats:
+                # external is not found, this should happen only for new externals. get the first element whichever it is and change its properties
+                self.externalsStats[ext] = [{"name":ext, "cpu_75":self.machineResources["total"]["cpu_75"]/4,"rss_75":self.machineResources["total"]["rss_75"]/10 }]
+            externals_to_run.append(self.externalsStats[ext][0])        
+        # first order them by metric and then run over to alloc resources
+        externalsList_sorted = [ext for ext in sorted(externals_to_run, key=lambda x: x[self.jobsOrderMetric], reverse=True)]
+
+        externals_to_run = []
+        for ex_stats in externalsList_sorted:
+            if (ex_stats["cpu_75"]<=self.machineResources["available"]["cpu_75"] and ex_stats["rss_75"]<=self.machineResources["available"]["rss_75"]):
+                self.resourcesAllocatedForExternals[ex_stats["name"]] = {}
+                for prm in ["rss_75", "cpu_75"]:
+                    self.machineResources["available"][prm] -= ex_stats[prm]
+                    self.resourcesAllocatedForExternals[ex_stats["name"]][prm] = ex_stats[prm]
+                externals_to_run.append(ext_name_to_fullname_dict[ex_stats["name"]]) # this gets the full names
+        return externals_to_run
+
+    def releaseResourcesForExternal(self, external): # external name
+        # get the external name only
+        external = external.split('+')[1]
+        for prm in ["rss_75", "cpu_75"]:
+            self.machineResources["available"][prm] += self.resourcesAllocatedForExternals[external][prm]
+        del self.resourcesAllocatedForExternals[external]


### PR DESCRIPTION
This is adding a class to handle available resources and run externals in parallel
It works as it did without this changes (tested) given no json file for the rmanager is provided, so it can work as it did except when we are testing it (DEVEL probably) , providing with additional argument
Testing shows we might have to use cpu90 and that memory wouldn't matter as much

Example is running openloops and root together, openloops slows down root compilation a lot although its cpu75 ~400 and also root's cpu75 is ~400 (and they should be able to run both smooth). 
Openloop's cpu90 however is ~1600 (which is more likely what to use)

Stats are missing, jenkins job is not failing but stats are not there, although we build them and the stat files are there

To run this in parallel, stats created by https://github.com/cms-sw/cms-bot/pull/1440 have to be given to cmsBuild 
