### PR TITLE
Remove the branch argument as unused/redundant

### DIFF
--- a/cmsBuild
+++ b/cmsBuild
@@ -525,7 +525,7 @@ def downloadGit(source, dest, options):
         args["submodules"] = ""
     command = format("cd %(exportpath)s &&"
                      "git init &&"
-                     "git pull --tags %(protocol)s%(gitroot)s refs/heads/%(branch)s &&"
+                     "git pull --tags %(protocol)s%(gitroot)s &&"
                      "git reset --hard %(tag)s && %(submodules)s"
                      "find . ! -path '%(filter)s' -delete &&"
                      "rm -rf .git .gitattributes .gitignore", **args)


### PR DESCRIPTION
When pulling all tags remote refs are not needed
for our purpose of getting the tags + hard reset to the tag of interest
Looks like line 529 is getting tags only
This helps with checking data repo tags without specifying branches, tags are not related to branches anyway, 
to avoid creating files with one line for new data repos

cmssw toolconf is building fine without this, I started it yesterday evening