### PR TITLE
Teach cmsBuild to make use of build stats to optimize the build time

### DIFF
--- a/cmsBuild
+++ b/cmsBuild
@@ -53,7 +53,7 @@ cmspkg_upload_cache = {"": []}
 rpm_upload_cache = {}
 removeInitialSpace = re.compile("^[ ]*", re.M)
 cmsBuildFilename = abspath(__file__)
-
+build_stats = None
 
 def fatal(message):
     print ("ERROR: " + message)
@@ -1501,6 +1501,13 @@ class PackageFactory(object):
                 pkg.specCache = False
                 log("Read from cache: %s" % pkg.pkgName())
             break
+        for dep in pkg.fullDependencies:
+          self[dep].requiredBy += 1
+        if build_stats:
+          pkg_time = 300 if pkg.name not in build_stats["packages"] else build_stats["packages"][pkg.name]["time"]
+          for dep in pkg.fullDependencies:
+            if dep in build_stats["packages"]:
+              build_stats["packages"][dep]["time"] += pkg_time
         self[pkgName] = pkg
         if pkg.name != pkgName:
             log("FATAL: Package name '%s' and spec name '%s' does not match" % (pkg.name, pkgName))
@@ -2106,6 +2113,7 @@ class Package(object):
         self.override_version = ""
         self.buildLogsToKeep = ""
         self.versionSuffix = True
+        self.requiredBy = 1
 
     def rpmLocation(self):
         return join(self.rpmdir, self.rpmfilename)
@@ -3642,6 +3650,9 @@ def checkPackageInCache(pkg, scheduler):
         if not isPackageInstalled(p):
             scheduler.serial("check-%s" % p.pkgName(), [], checkPackageInCache, p, scheduler)
             buildActionDependencies.append("install-%s" % p.pkgName())
+    for p in getPackages(pkg.fullDependencies):
+        if not isPackageInstalled(p):
+            scheduler.serial("check-%s" % p.pkgName(), [], checkPackageInCache, p, scheduler)
     installActionDependencies = ["build-%s" % pkgName]
     scheduler.log("Dependencies for %s: %s" % (pkgName, buildActionDependencies))
     scheduler.parallel("build-%s" % pkgName, buildActionDependencies, buildPackage, pkg, scheduler)
@@ -3655,9 +3666,9 @@ def checkPackageInCache(pkg, scheduler):
 
 
 # New version using the new scheduler.
-def buildSpecs(topLevelPackages, buildStats=None):
+def buildSpecs(topLevelPackages):
     from scheduler import Scheduler
-    scheduler = Scheduler(topLevelPackages[0].options.workersPoolSize, log, buildStats)
+    scheduler = Scheduler(topLevelPackages[0].options.workersPoolSize, log, build_stats)
     for pkg in topLevelPackages:
         if not isPackageInstalled(pkg):
             scheduler.serial("check-%s" % pkg.pkgName(), [], checkPackageInCache, pkg, scheduler)
@@ -3739,13 +3750,7 @@ def build(opts, args, factory):
     if opts.pretend:
         log("Option --pretend specified. Not building.")
         return
-    build_stats = None
-    if opts.externalsStatsFile and os.path.exists(opts.externalsStatsFile):
-        # read the stats from a json file, also the machine specifics are there
-        from json import load
-        with open(opts.externalsStatsFile) as f:
-            build_stats = load(f)
-    buildSpecs(packages, build_stats)
+    buildSpecs(packages)
 
 def isPackageInstalled(pkg):
     if pkg.options.bootstrap:
@@ -4271,6 +4276,11 @@ if __name__ == "__main__":
     environ["LC_ALL"] = "C"
     opts, args = parseOptions()
     checkOptionsLocalSource(opts)
+    if opts.externalsStatsFile and os.path.exists(opts.externalsStatsFile):
+        # read the stats from a json file, also the machine specifics are there
+        from json import load
+        with open(opts.externalsStatsFile) as f:
+            build_stats = load(f)
 
     packages = {}
     # tags_cache = TagCacheAptImpl (opts)

--- a/cmsBuild
+++ b/cmsBuild
@@ -2891,6 +2891,13 @@ def parseOptions():
     advancedBuildOptions.add_option("--ldps", "--log-deps",
                                     dest="depsLog", action="store_true",
                                     default=False, help="store json formatted log of dependencies in workDir/WEB/arch")
+    # give the stats to the script instad of making it running a script from here to do it
+    advancedBuildOptions.add_option("--estats", "--externals-stats",
+                                    dest="externalsStatsFile",
+                                    default=None,
+                                    metavar="FILENAME",
+                                    help="JSON file with externals compilation metrics, from elastic search or default from github")
+
     # FIXME: change option to --no-deprecate and do the deprecation
     #        automatically by default.
     # parser.add_option ("--deprecate-local",
@@ -3648,9 +3655,9 @@ def checkPackageInCache(pkg, scheduler):
 
 
 # New version using the new scheduler.
-def buildSpecs(topLevelPackages):
+def buildSpecs(topLevelPackages, buildStats=None):
     from scheduler import Scheduler
-    scheduler = Scheduler(topLevelPackages[0].options.workersPoolSize, log)
+    scheduler = Scheduler(topLevelPackages[0].options.workersPoolSize, log, buildStats)
     for pkg in topLevelPackages:
         if not isPackageInstalled(pkg):
             scheduler.serial("check-%s" % pkg.pkgName(), [], checkPackageInCache, pkg, scheduler)
@@ -3732,8 +3739,13 @@ def build(opts, args, factory):
     if opts.pretend:
         log("Option --pretend specified. Not building.")
         return
-    buildSpecs(packages)
-
+    build_stats = None
+    if opts.externalsStatsFile and os.path.exists(opts.externalsStatsFile):
+        # read the stats from a json file, also the machine specifics are there
+        from json import load
+        with open(opts.externalsStatsFile) as f:
+            build_stats = load(f)
+    buildSpecs(packages, build_stats)
 
 def isPackageInstalled(pkg):
     if pkg.options.bootstrap:

--- a/rmanager.py
+++ b/rmanager.py
@@ -8,7 +8,7 @@ class ResourceManager(object):
         self.allocated = {}
         self.highestPriortyOnly = highestPriortyOnly
         self.priorityList = ["time"] # can be any list from the stat keys
-    
+
     def allocResourcesForExternals(self, externalsList, count=1000): # return ordered list for externals that can be started
         externals_to_run = []
         if count<=0: return externals_to_run

--- a/rmanager.py
+++ b/rmanager.py
@@ -1,47 +1,54 @@
+import re
 class ResourceManager(object):
-    def __init__(self, ESstats, cpu_percent_usage, memory_percent_usage, njobs):
-        self.machineResources = { "total": {"cpu_90": cpu_percent_usage*int(ESstats["MachineCPUCount"]),
-                                            "rss_75" : memory_percent_usage*int(ESstats["MachineMemoryGB"])*10737418 },
-                                  "available": {"cpu_90": cpu_percent_usage*int(ESstats["MachineCPUCount"]),
-                                            "rss_75" : memory_percent_usage*int(ESstats["MachineMemoryGB"])*10737418 } }
-        self.externalsStats = ESstats["externals"]# this should be get before running pkgtools
-        self.resourcesAllocatedForExternals = {} # resources that were alocated for given externals, say root -> "root": {"rss":"", cpu:""}
-        self.priorityList = ["time", "cpu_90"] # can be any list from the stat keys
-        self.missingExternalsStrategy = None # runFirst, runLast
+    def __init__(self, ESstats, scheduler, highestPriortyOnly = False):
+        self.esStats = ESstats
+        self.scheduler = scheduler
+        self.machineResources = ESstats["resources"]
+        self.resouceList = ["cpu", "rss"]
+        self.allocated = {}
+        self.highestPriortyOnly = highestPriortyOnly
+        self.priorityList = ["time"] # can be any list from the stat keys
     
-    def allocResourcesForExternals(self, externalsList=[]): # return ordered list for externals that can be started
-        # first, strip the names from build-*++version and make a tmp name to full name dict.
-        # toolfiles should not arrive here, but will also work if they do
-        ext_name_to_fullname_dict = {}
-        for e in externalsList:
-            short_name = e.split('+')[1]
-            ext_name_to_fullname_dict[short_name]=e
-        externalsList_shortNames = ext_name_to_fullname_dict.keys()
-        # If record for an external is not available, allocate it half the cpu and 1/6th RAM from the resources to run it
-        # OR allocate all resources for each missing external, forcing them to build last one by one.
+    def allocResourcesForExternals(self, externalsList, count=1000): # return ordered list for externals that can be started
         externals_to_run = []
-        for ext in externalsList_shortNames:
-            if ext not in self.externalsStats:
-                # external is not found, this should happen only for new externals. get the first element whichever it is and change its properties
-                print 'external: ', ext, 'not found, create entry for it'
-                self.externalsStats[ext] = [{"name":ext, "cpu_90":self.machineResources["total"]["cpu_90"]/2,"rss_75":self.machineResources["total"]["rss_75"]/6,"time":1800 }]
-            externals_to_run.append(self.externalsStats[ext][0])
+        if count<=0: return externals_to_run
+        for ext_full in externalsList:
+            stats = {"name": ext_full}
+            ext = ext_full.split('+')[1]
+            if ext not in self.esStats["packages"]:
+                idx = -1
+                for exp in self.esStats["known"]:
+                    if re.match(exp[0], ext):
+                        idx = exp[1]
+                        break
+                for k in self.esStats["defaults"]:
+                    stats[k] = self.esStats["defaults"][k][idx]
+                self.scheduler.log("New external found, creating default entry %s" % stats)
+            else:
+                for k in self.esStats["defaults"]:
+                    stats[k] = self.esStats["packages"][ext][k]
+            externals_to_run.append(stats)
         # first order them by metric and then run over to alloc resources
         externalsList_sorted = [ext for ext in sorted(externals_to_run, key=lambda x: tuple(x[k] for k in self.priorityList), reverse=True)]
-
-        externals_to_run = []
+        externals_ordered = []
         for ex_stats in externalsList_sorted:
-            if (ex_stats["cpu_90"]<=self.machineResources["available"]["cpu_90"] and ex_stats["rss_75"]<=self.machineResources["available"]["rss_75"]):
-                self.resourcesAllocatedForExternals[ex_stats["name"]] = {}
-                for prm in ["rss_75", "cpu_90"]:
-                    self.machineResources["available"][prm] -= ex_stats[prm]
-                    self.resourcesAllocatedForExternals[ex_stats["name"]][prm] = ex_stats[prm]
-                externals_to_run.append(ext_name_to_fullname_dict[ex_stats["name"]]) # this gets the full names
-        return externals_to_run
+            if not [r for r in self.resouceList if ex_stats[r]>self.machineResources[r]]:
+                for prm in self.resouceList:
+                    self.machineResources[prm] -= ex_stats[prm]
+                externals_ordered.append(ex_stats["name"])
+                self.allocated[ex_stats["name"]] = ex_stats
+                self.scheduler.log("Allocating resouces %s" % ex_stats)
+                count-=1
+                if count<=0:
+                  break
+            elif self.highestPriortyOnly:
+              break
+        self.scheduler.log("Available resouces %s" % self.machineResources)
+        return externals_ordered
 
-    def releaseResourcesForExternal(self, external): # external name
-        # get the external name only
-        external = external.split('+')[1]
-        for prm in ["rss_75", "cpu_90"]:
-            self.machineResources["available"][prm] += self.resourcesAllocatedForExternals[external][prm]
-        del self.resourcesAllocatedForExternals[external]
+    def releaseResourcesForExternal(self, external):
+        if external not in self.allocated: return
+        for prm in self.resouceList:
+            self.machineResources[prm] +=  self.allocated[external][prm]
+        self.scheduler.log("Released resources: %s , %s" % (self.allocated[external], self.machineResources))
+        del self.allocated[external]

--- a/rmanager.py
+++ b/rmanager.py
@@ -1,12 +1,12 @@
 class ResourceManager(object):
     def __init__(self, ESstats, cpu_percent_usage, memory_percent_usage, njobs):
-        self.machineResources = { "total": {"cpu_75": cpu_percent_usage*int(ESstats["MachineCPUCount"]), 
+        self.machineResources = { "total": {"cpu_90": cpu_percent_usage*int(ESstats["MachineCPUCount"]),
                                             "rss_75" : memory_percent_usage*int(ESstats["MachineMemoryGB"])*10737418 },
-                                  "available": {"cpu_75": cpu_percent_usage*int(ESstats["MachineCPUCount"]),
+                                  "available": {"cpu_90": cpu_percent_usage*int(ESstats["MachineCPUCount"]),
                                             "rss_75" : memory_percent_usage*int(ESstats["MachineMemoryGB"])*10737418 } }
         self.externalsStats = ESstats["externals"]# this should be get before running pkgtools
         self.resourcesAllocatedForExternals = {} # resources that were alocated for given externals, say root -> "root": {"rss":"", cpu:""}
-        self.jobsOrderMetric = "cpu_75" # default to cpu
+        self.priorityList = ["time", "cpu_90"] # can be any list from the stat keys
         self.missingExternalsStrategy = None # runFirst, runLast
     
     def allocResourcesForExternals(self, externalsList=[]): # return ordered list for externals that can be started
@@ -17,22 +17,23 @@ class ResourceManager(object):
             short_name = e.split('+')[1]
             ext_name_to_fullname_dict[short_name]=e
         externalsList_shortNames = ext_name_to_fullname_dict.keys()
-        # if record for an external is not available, allocate it 1/4th of the resources and run it first
+        # If record for an external is not available, allocate it half the cpu and 1/6th RAM from the resources to run it
         # OR allocate all resources for each missing external, forcing them to build last one by one.
         externals_to_run = []
         for ext in externalsList_shortNames:
             if ext not in self.externalsStats:
                 # external is not found, this should happen only for new externals. get the first element whichever it is and change its properties
-                self.externalsStats[ext] = [{"name":ext, "cpu_75":self.machineResources["total"]["cpu_75"]/4,"rss_75":self.machineResources["total"]["rss_75"]/10 }]
-            externals_to_run.append(self.externalsStats[ext][0])        
+                print 'external: ', ext, 'not found, create entry for it'
+                self.externalsStats[ext] = [{"name":ext, "cpu_90":self.machineResources["total"]["cpu_90"]/2,"rss_75":self.machineResources["total"]["rss_75"]/6,"time":1800 }]
+            externals_to_run.append(self.externalsStats[ext][0])
         # first order them by metric and then run over to alloc resources
-        externalsList_sorted = [ext for ext in sorted(externals_to_run, key=lambda x: x[self.jobsOrderMetric], reverse=True)]
+        externalsList_sorted = [ext for ext in sorted(externals_to_run, key=lambda x: tuple(x[k] for k in self.priorityList), reverse=True)]
 
         externals_to_run = []
         for ex_stats in externalsList_sorted:
-            if (ex_stats["cpu_75"]<=self.machineResources["available"]["cpu_75"] and ex_stats["rss_75"]<=self.machineResources["available"]["rss_75"]):
+            if (ex_stats["cpu_90"]<=self.machineResources["available"]["cpu_90"] and ex_stats["rss_75"]<=self.machineResources["available"]["rss_75"]):
                 self.resourcesAllocatedForExternals[ex_stats["name"]] = {}
-                for prm in ["rss_75", "cpu_75"]:
+                for prm in ["rss_75", "cpu_90"]:
                     self.machineResources["available"][prm] -= ex_stats[prm]
                     self.resourcesAllocatedForExternals[ex_stats["name"]][prm] = ex_stats[prm]
                 externals_to_run.append(ext_name_to_fullname_dict[ex_stats["name"]]) # this gets the full names
@@ -41,6 +42,6 @@ class ResourceManager(object):
     def releaseResourcesForExternal(self, external): # external name
         # get the external name only
         external = external.split('+')[1]
-        for prm in ["rss_75", "cpu_75"]:
+        for prm in ["rss_75", "cpu_90"]:
             self.machineResources["available"][prm] += self.resourcesAllocatedForExternals[external][prm]
         del self.resourcesAllocatedForExternals[external]

--- a/rmanager.py
+++ b/rmanager.py
@@ -1,0 +1,46 @@
+class ResourceManager(object):
+    def __init__(self, ESstats, cpu_percent_usage, memory_percent_usage, njobs):
+        self.machineResources = { "total": {"cpu_75": cpu_percent_usage*int(ESstats["MachineCPUCount"]), 
+                                            "rss_75" : memory_percent_usage*int(ESstats["MachineMemoryGB"])*10737418 },
+                                  "available": {"cpu_75": cpu_percent_usage*int(ESstats["MachineCPUCount"]),
+                                            "rss_75" : memory_percent_usage*int(ESstats["MachineMemoryGB"])*10737418 } }
+        self.externalsStats = ESstats["externals"]# this should be get before running pkgtools
+        self.resourcesAllocatedForExternals = {} # resources that were alocated for given externals, say root -> "root": {"rss":"", cpu:""}
+        self.jobsOrderMetric = "cpu_75" # default to cpu
+        self.missingExternalsStrategy = None # runFirst, runLast
+    
+    def allocResourcesForExternals(self, externalsList=[]): # return ordered list for externals that can be started
+        # first, strip the names from build-*++version and make a tmp name to full name dict.
+        # toolfiles should not arrive here, but will also work if they do
+        ext_name_to_fullname_dict = {}
+        for e in externalsList:
+            short_name = e.split('+')[1]
+            ext_name_to_fullname_dict[short_name]=e
+        externalsList_shortNames = ext_name_to_fullname_dict.keys()
+        # if record for an external is not available, allocate it 1/4th of the resources and run it first
+        # OR allocate all resources for each missing external, forcing them to build last one by one.
+        externals_to_run = []
+        for ext in externalsList_shortNames:
+            if ext not in self.externalsStats:
+                # external is not found, this should happen only for new externals. get the first element whichever it is and change its properties
+                self.externalsStats[ext] = [{"name":ext, "cpu_75":self.machineResources["total"]["cpu_75"]/4,"rss_75":self.machineResources["total"]["rss_75"]/10 }]
+            externals_to_run.append(self.externalsStats[ext][0])        
+        # first order them by metric and then run over to alloc resources
+        externalsList_sorted = [ext for ext in sorted(externals_to_run, key=lambda x: x[self.jobsOrderMetric], reverse=True)]
+
+        externals_to_run = []
+        for ex_stats in externalsList_sorted:
+            if (ex_stats["cpu_75"]<=self.machineResources["available"]["cpu_75"] and ex_stats["rss_75"]<=self.machineResources["available"]["rss_75"]):
+                self.resourcesAllocatedForExternals[ex_stats["name"]] = {}
+                for prm in ["rss_75", "cpu_75"]:
+                    self.machineResources["available"][prm] -= ex_stats[prm]
+                    self.resourcesAllocatedForExternals[ex_stats["name"]][prm] = ex_stats[prm]
+                externals_to_run.append(ext_name_to_fullname_dict[ex_stats["name"]]) # this gets the full names
+        return externals_to_run
+
+    def releaseResourcesForExternal(self, external): # external name
+        # get the external name only
+        external = external.split('+')[1]
+        for prm in ["rss_75", "cpu_75"]:
+            self.machineResources["available"][prm] += self.resourcesAllocatedForExternals[external][prm]
+        del self.resourcesAllocatedForExternals[external]

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,16 +1,15 @@
 from __future__ import print_function
 import sys
 if sys.version_info[0] == 2:
-  from Queue import Queue
+  from Queue import Queue, PriorityQueue
   from StringIO import StringIO
 else:
-  from queue import Queue
+  from queue import Queue, PriorityQueue
   from io import StringIO
 from threading import Thread
 from time import sleep
 import threading
 import traceback
-from StringIO import StringIO
 from rmanager import ResourceManager
 
 # Helper class to avoid conflict between result
@@ -44,8 +43,8 @@ class Scheduler(object):
   # There is one, special, "final-job" which depends on all the scheduled jobs
   # either parallel or serial. This job is guaranteed to be executed last and
   # avoids having deadlocks due to all the queues having been disposed.
-  def __init__(self, parallelThreads, logDelegate=None, buildStats=None):
-    self.workersQueue = Queue()
+  def __init__(self, parallelThreads, logDelegate=None, buildStats=None, parallelDownloads=2):
+    self.workersQueue = PriorityQueue()
     self.resultsQueue = Queue()
     self.notifyQueue = Queue()
     self.rescheduleParallel = False
@@ -55,14 +54,15 @@ class Scheduler(object):
     self.runningJobsCache = []
     self.doneJobs = []
     self.brokenJobs = []
-    self.parallelThreads = parallelThreads
+    self.parallelThreads = parallelThreads+parallelDownloads
     self.logDelegate = logDelegate
     self.resourceManager = None
+    self.runningJobsCount = {"build": 0, "fetch": 0, "download": 0, "max_build": parallelThreads, "max_download": parallelDownloads}
     self.errors = {}
     if not logDelegate:
       self.logDelegate = self.__doLog 
     if buildStats:
-      self.resourceManager = ResourceManager(buildStats, 100, 100, parallelThreads)
+      self.resourceManager = ResourceManager(buildStats, self)
     # Add a final job, which will depend on any spawned task so that we do not
     # terminate until we are completely done.
     self.finalJobDeps = []
@@ -103,7 +103,7 @@ class Scheduler(object):
   def __createWorker(self):
     def worker():
       while True:
-        taskId, item = self.workersQueue.get()
+        pri, taskId, item = self.workersQueue.get()
         try:
           result = item[0](*item[1:])
         except Exception as e:
@@ -116,10 +116,8 @@ class Scheduler(object):
           return
         self.log(str(item) + " done")
         self.notifyMaster(self.__updateJobStatus, taskId, result)
-        if self.resourceManager and taskId.startswith('build-') and 'toolfile' not in taskId:
-          print('releasing resources for: ', taskId, " available" ,self.resourceManager.machineResources["available"])
+        if self.resourceManager and taskId.startswith('build-'):
           self.notifyMaster(self.resourceManager.releaseResourcesForExternal, taskId)
-          print('after release: ', self.resourceManager.machineResources["available"])
         self.notifyMaster(self.__rescheduleParallel)
     return worker
 
@@ -136,7 +134,9 @@ class Scheduler(object):
 
   def parallel(self, taskId, deps, *spec):
     if taskId in self.jobs: return
-    self.jobs[taskId] = {"scheduler": "parallel", "deps": deps, "spec":spec}
+    self.jobs[taskId] = {"scheduler": "parallel", "deps": deps, "spec":spec, "priorty": 1}
+    if taskId.split("-")[0] in ["build", "download", "fetch"]:
+      self.jobs[taskId]["priorty"] = 100000-spec[1].requiredBy
     self.pendingJobs.append(taskId)
     self.finalJobDeps.append(taskId)
 
@@ -169,32 +169,49 @@ class Scheduler(object):
       self.runningJobsCache = self.runningJobs[:]
       self.log("Running tasks: %s" % self.runningJobs,30)
 
-    nonBuildJobs = []
-    buildJobs =[]
-
+    allJobs =[]
     for taskId in parallelJobs:
       pendingDeps = [dep for dep in self.jobs[taskId]["deps"] if not dep in self.doneJobs]
       if pendingDeps:
         if dumpMsg:
           self.log("Pending tasks: %s: %s" % (taskId, pendingDeps),30)
         continue
-      # No broken dependencies and no pending ones. we can continue.
-      # Only build jobs without toolfiles 
-      if (taskId.startswith('build-') and 'toolfile' not in taskId):
-        buildJobs.append(taskId)
+      allJobs.append({"id": taskId, "priorty": self.jobs[taskId]["priorty"]})
+    buildJobs =[]
+    downloadJobs = []
+    forceJobs = []
+    bldCount = self.runningJobsCount["max_build"]-self.runningJobsCount["build"]
+    dwnCount = self.runningJobsCount["max_download"]-self.runningJobsCount["download"]
+    for task in sorted(allJobs, key=lambda k: k['priorty']):
+      taskId = task["id"]
+      taskType = taskId.split("-")[0]
+      if taskType == "download":
+        if dwnCount>0:
+          downloadJobs.append(taskId)
+          dwnCount -= 1
+      elif taskType == "build":
+        if bldCount>0: #include all build jobs so that we can match those which can be run
+          buildJobs.append(taskId)
       else:
-        nonBuildJobs.append(taskId)
-    if self.resourceManager:
-      print('available resources: ', self.resourceManager.machineResources["available"])
-      buildJobs = self.resourceManager.allocResourcesForExternals(buildJobs)
-      print('allocating resources for ', buildJobs, ' available:  ', self.resourceManager.machineResources["available"])
-    # put the build jobs on the queue first
-    for taskId in buildJobs + nonBuildJobs:
+        forceJobs.append(taskId)
+    if bldCount>0 and buildJobs:
+      if self.resourceManager:
+        buildJobs = self.resourceManager.allocResourcesForExternals(buildJobs, count=bldCount)
+      else:
+        buildJobs = buildJobs[:bldCount]
+    for taskId in forceJobs + downloadJobs + buildJobs:
+      taskType = taskId.split("-")[0]
+      self.runningJobsCount[taskType] += 1
+      self.log("%s" % self.runningJobsCount)
       transition(taskId, self.pendingJobs, self.runningJobs)
-      self.__scheduleParallel(taskId, self.jobs[taskId]["spec"])
+      self.__scheduleParallel(taskId, self.jobs[taskId]["spec"], priorty=self.jobs[taskId]["priorty"])
 
   # Update the job with the result of running.
   def __updateJobStatus(self, taskId, error):
+    taskType = taskId.split("-")[0]
+    if taskType in self.runningJobsCount:
+      self.runningJobsCount[taskType] -= 1
+      self.log("%s" % self.runningJobsCount)
     if not error:
       transition(taskId, self.runningJobs, self.doneJobs)
       return
@@ -202,8 +219,8 @@ class Scheduler(object):
     self.errors[taskId] = error
   
   # One task at the time.
-  def __scheduleParallel(self, taskId, commandSpec):
-    self.workersQueue.put((taskId, commandSpec))
+  def __scheduleParallel(self, taskId, commandSpec, priorty=1):
+    self.workersQueue.put((priorty, taskId, commandSpec))
 
   # Helper to enqueue commands for all the threads.
   def shout(self, *commandSpec):

--- a/scheduler.py
+++ b/scheduler.py
@@ -10,6 +10,8 @@ from threading import Thread
 from time import sleep
 import threading
 import traceback
+from StringIO import StringIO
+from rmanager import ResourceManager
 
 # Helper class to avoid conflict between result
 # codes and quit state transition.
@@ -42,7 +44,7 @@ class Scheduler(object):
   # There is one, special, "final-job" which depends on all the scheduled jobs
   # either parallel or serial. This job is guaranteed to be executed last and
   # avoids having deadlocks due to all the queues having been disposed.
-  def __init__(self, parallelThreads, logDelegate=None):
+  def __init__(self, parallelThreads, logDelegate=None, buildStats=None):
     self.workersQueue = Queue()
     self.resultsQueue = Queue()
     self.notifyQueue = Queue()
@@ -55,9 +57,12 @@ class Scheduler(object):
     self.brokenJobs = []
     self.parallelThreads = parallelThreads
     self.logDelegate = logDelegate
+    self.resourceManager = None
     self.errors = {}
     if not logDelegate:
       self.logDelegate = self.__doLog 
+    if buildStats:
+      self.resourceManager = ResourceManager(buildStats, 100, 100, parallelThreads)
     # Add a final job, which will depend on any spawned task so that we do not
     # terminate until we are completely done.
     self.finalJobDeps = []
@@ -111,6 +116,10 @@ class Scheduler(object):
           return
         self.log(str(item) + " done")
         self.notifyMaster(self.__updateJobStatus, taskId, result)
+        if self.resourceManager and taskId.startswith('build-') and 'toolfile' not in taskId:
+          print('releasing resources for: ', taskId, " available" ,self.resourceManager.machineResources["available"])
+          self.notifyMaster(self.resourceManager.releaseResourcesForExternal, taskId)
+          print('after release: ', self.resourceManager.machineResources["available"])
         self.notifyMaster(self.__rescheduleParallel)
     return worker
 
@@ -159,6 +168,10 @@ class Scheduler(object):
     if dumpMsg:
       self.runningJobsCache = self.runningJobs[:]
       self.log("Running tasks: %s" % self.runningJobs,30)
+
+    nonBuildJobs = []
+    buildJobs =[]
+
     for taskId in parallelJobs:
       pendingDeps = [dep for dep in self.jobs[taskId]["deps"] if not dep in self.doneJobs]
       if pendingDeps:
@@ -166,6 +179,17 @@ class Scheduler(object):
           self.log("Pending tasks: %s: %s" % (taskId, pendingDeps),30)
         continue
       # No broken dependencies and no pending ones. we can continue.
+      # Only build jobs without toolfiles 
+      if (taskId.startswith('build-') and 'toolfile' not in taskId):
+        buildJobs.append(taskId)
+      else:
+        nonBuildJobs.append(taskId)
+    if self.resourceManager:
+      print('available resources: ', self.resourceManager.machineResources["available"])
+      buildJobs = self.resourceManager.allocResourcesForExternals(buildJobs)
+      print('allocating resources for ', buildJobs, ' available:  ', self.resourceManager.machineResources["available"])
+    # put the build jobs on the queue first
+    for taskId in buildJobs + nonBuildJobs:
       transition(taskId, self.pendingJobs, self.runningJobs)
       self.__scheduleParallel(taskId, self.jobs[taskId]["spec"])
 


### PR DESCRIPTION
Based on #172.
These changes allows cmsBuild to make use of build stats from previous runs and optimize the parallel build of multiple packages ( as long as the cpu and memory consumption of packages is under max cpu/memory limit). The format of build stats json file should be
```
{
  # Some default values for unknown packages
  "defaults": {
    "cpu": (cpu%_single_process_jobs, cpu%_multi_process_jobs),
    "rss": (rss_in_bytes_single_process_jobs, rss_in_bytes_multi_process_jobs),
    "time": (build_time_single_process_job, build_time_for_multi_process_jobs)
  },
  # maximum resources available
  "resources":{"cpu": max_cpu%_available, "rss": max_memory_available},
  # stats of packages
  "packages": { "name": {"cpu": value, "rss": value, "time": value}},
  # some defaults for known packages, first item is name of package to match and 2nd item is the index in the data["defaults"] for a resource
  "known": [
    (package_regexp, index_in_default), 
    ]
  }
```
e.g.
```
{
  "defaults": {
    "cpu": (50, total_cpu%/4),
    "rss": (total_memory/total_cpu, total_memory/4),
    "time": (1, 300)
  },
  "resources":{"cpu": total_cpu%, "rss": total_memory},
  "packages": {
    "root": {"cpu": 800, "rss": 8GB, "time": 3600},
    "boost": {"cpu": 640, "rss": 4GB, "time": 1800}
  },
  "known": [
    ("^.+-toolfile$", 0), 
    ("^data-.+$", 0),
    ("^.+$", 1)
    ]
  }
```

here are some build results on a 16 core build machine
1- Old pkgtools with `--builders 1 -j 16` : build time 12h15 for all externals (except gcc)

![old-1builder](https://user-images.githubusercontent.com/4115138/111609925-141d8a80-87db-11eb-83f9-502dd805f50e.jpg)

2- Old pkgtools with  `--builders 3 -j 16` : build time 8h10 for all externals (except gcc)

![old-3builders](https://user-images.githubusercontent.com/4115138/111609984-24ce0080-87db-11eb-8eb0-a44493cbac84.jpg)

3- New pkgtools with  `--builders 16 -j 16 --esstats stats-from-step1.json`  : build time 5h50

![new](https://user-images.githubusercontent.com/4115138/111610667-e553e400-87db-11eb-9577-1ef88b93f453.jpg)

