### PR TITLE
Allow packages to geneate sources during the build

### DIFF
--- a/cmsBuild
+++ b/cmsBuild
@@ -2710,9 +2710,7 @@ class Package(object):
         if PKGFactory.getRequiresCache().has_key(self.name):
             return PKGFactory.getRequiresCache()[self.name]
         spec = open(self.tmpspec, "w")
-        text = ""
-        if oldSourcesNumbers:
-            text += getSourcesChecksum(self, oldSourcesNumbers)
+        text = "" if (not oldSourcesNumbers) else getSourcesChecksum(self, oldSourcesNumbers)
         text += "\n".join([self.specPreHeader,
                           SPEC_HEADER % self.__dict__,
                           PKGFactory.postProcessSpec(PKGFactory.preamble),

--- a/cmsBuild
+++ b/cmsBuild
@@ -664,10 +664,11 @@ downloadHandlers = {'cvs': downloadCvs,
                     'usercommand': downloadUserCommand}
 
 def fixUrl(s):
-    if 'no-cmssdt-cache=1' in s:
-        s = s.replace('no-cmssdt-cache=1','').replace("&&","&").replace("?&","?")
-        if s.endswith('&'): s=s[:-1]
-        if s.endswith('?'): s=s[:-1]
+    for x in ['no-cmssdt-cache=1', 'cmdist-generated=1']:
+        if x in s:
+            s = s.replace(x,'').replace("&&","&").replace("?&","?")
+            if s.endswith('&'): s=s[:-1]
+            if s.endswith('?'): s=s[:-1]
     return s
 
 def getUrlChecksum(s):
@@ -788,6 +789,7 @@ def download(source, dest, options, pkg=None):
     # FIXME `options` are the same as `pkg.options`
     source_name = pkg.sourcesNumbers[source] if pkg else None
     noCmssdtCache = True if 'no-cmssdt-cache=1' in source else False
+    isCmsdistGenerated = True if 'cmdist-generated=1' in source else False
     source = fixUrl(source)
     checksum = getUrlChecksum(source)
 
@@ -865,7 +867,7 @@ def download(source, dest, options, pkg=None):
         f.close()
         if dest and exists(realFile) and not exists(join(dest, filename)):
             symlink(realFile, join(dest, filename))
-    return success
+    return (success or isCmsdistGenerated)
 
 
 class MalformedUrl(Exception):
@@ -1264,6 +1266,25 @@ except ImportError:
     from hashlib import md5 as md5adder
 
 
+def getSourcesChecksum(pkg, sourcesNumbers):
+    text = ""
+    has_cmsdist_generated = False
+    for s in sourcesNumbers:
+        if 'cmdist-generated=1' in s:
+            has_cmsdist_generated = True
+            chksum = getUrlChecksum(fixUrl(s))
+            text += "%%define cmsdist_chksum_%s %s\n" % (sourcesNumbers[s].lower(), chksum)
+    if has_cmsdist_generated:
+        for s in sourcesNumbers:
+            filename = join(pkg.options.cmsdist, s+".file")
+            if exists(filename):
+                f = open(filename, 'rb')
+                m = md5adder(f.read())
+                f.close()
+                chksum = m.hexdigest()
+                text += "%%define cmsdist_chksum_%s %s\n" % (sourcesNumbers[s].lower(), chksum)
+    return text
+
 def calculateHumanReadableVersion(pkg):
     # This takes care of converting a checksum to something human-readable.
     #  * If the package has a revision different than 1, we assume that it is
@@ -1345,7 +1366,7 @@ class HeaderMatchingRegexps(object):
         self.REQUIRES_REGEXP = re.compile("^Requires: (.*)")
         self.REMOTE_SOURCE_REGEXP = re.compile("^([Ss]ource[0-9]*): (.*:.*/.*)")
         self.REMOTE_PATCH_REGEXP = re.compile("^[Pp]atch[0-9]*: (.*:.*/.*)")
-        self.LOCAL_SOURCE_REGEXP = re.compile("^[Ss]ource[0-9]*: (.*)")
+        self.LOCAL_SOURCE_REGEXP = re.compile("^([Ss]ource[0-9]*): (.*)")
         self.LOCAL_PATCH_REGEXP = re.compile("^[Pp]atch[0-9]*: (.*)")
         self.BUILD_REQUIRES_REGEXP = re.compile("^BuildRequires: (.*)")
 
@@ -2523,6 +2544,10 @@ class Package(object):
                                SPEC_HEADER % self.__dict__,
                                PKGFactory.preamble])
         if self.options.reference: self.spec += format(SPEC_REFERENCE_REPO, reference_repo=self.options.reference)
+        if saveScripts:
+            xtext = getSourcesChecksum(self, self.sourcesNumbers)
+            if xtext:
+                self.spec += "\n"+xtext
         for section in self.sections.keys():
             for subsection in self.sections[section].keys():
                 sectionContents = self.sections[section][subsection].strip("\n ")
@@ -2683,11 +2708,14 @@ class Package(object):
         else:
             return cmp(self.name, other.name)
 
-    def getRequiresAndSources(self, subpackage=''):
+    def getRequiresAndSources(self, subpackage='', oldSourcesNumbers=None):
         if PKGFactory.getRequiresCache().has_key(self.name):
             return PKGFactory.getRequiresCache()[self.name]
         spec = open(self.tmpspec, "w")
-        text = "\n".join([self.specPreHeader,
+        text = ""
+        if oldSourcesNumbers:
+            text += getSourcesChecksum(self, oldSourcesNumbers)
+        text += "\n".join([self.specPreHeader,
                           SPEC_HEADER % self.__dict__,
                           PKGFactory.postProcessSpec(PKGFactory.preamble),
                           "%%description",
@@ -2716,13 +2744,14 @@ class Package(object):
             return source
 
         sourcesNumbers = {}
+        has_checksum_source = False
         for line in popen(queryCommand).readlines():
             line = re.sub("[\s]+", " ", line).strip("\n\t ")
             for rule, target in matchers:
                 match = rule.match(line)
                 if not match:
                     continue
-                if regexps.REMOTE_SOURCE_REGEXP != rule:
+                if rule not in [regexps.REMOTE_SOURCE_REGEXP, regexps.LOCAL_SOURCE_REGEXP]:
                     target.extend([element for element in match.group(1).split()])
                 else:
                     for src_num, url in [match.groups()]:
@@ -2730,7 +2759,10 @@ class Package(object):
                             element = fixSource(element.strip())
                             target.append(element)
                             sourcesNumbers[element] = src_num
+                            if '%{cmsdist_chksum_source' in element: has_checksum_source=True
                 break
+        if has_checksum_source and (not oldSourcesNumbers):
+            return self.getRequiresAndSources(subpackage, sourcesNumbers)
         cmsdistPath = abspath(self.options.cmsdist)
 
         # If no site is set, simply returns the original dependency name.

--- a/cmsBuild
+++ b/cmsBuild
@@ -1272,8 +1272,7 @@ def getSourcesChecksum(pkg, sourcesNumbers):
     for s in sourcesNumbers:
         if 'cmdist-generated=1' in s:
             has_cmsdist_generated = True
-            chksum = getUrlChecksum(fixUrl(s))
-            text += "%%define cmsdist_chksum_%s %s\n" % (sourcesNumbers[s].lower(), chksum)
+            text += "%%define cmsdist_chksum_%s %s\n" % (sourcesNumbers[s].lower(), getUrlChecksum(fixUrl(s)))
     if has_cmsdist_generated:
         for s in sourcesNumbers:
             filename = join(pkg.options.cmsdist, s+".file")
@@ -1281,8 +1280,7 @@ def getSourcesChecksum(pkg, sourcesNumbers):
                 f = open(filename, 'rb')
                 m = md5adder(f.read())
                 f.close()
-                chksum = m.hexdigest()
-                text += "%%define cmsdist_chksum_%s %s\n" % (sourcesNumbers[s].lower(), chksum)
+                text += "%%define cmsdist_chksum_%s %s\n" % (sourcesNumbers[s].lower(), m.hexdigest())
     return text
 
 def calculateHumanReadableVersion(pkg):


### PR DESCRIPTION
There is use case where package dynamically download sources during the build. The change allows cmsBuidl to allow such packages to upload such sources so that on next re-build it can download the previously cached source. One of such package is openloops where it download list of openloops processes