### PR TITLE
Always download sources with pip download

### DIFF
--- a/cmsBuild
+++ b/cmsBuild
@@ -625,9 +625,6 @@ def downloadPip(source, dest, options):
     pack = pkg[0].strip()
     pypi_file = '%s-%s.tar.gz' % (pack, pkg[1].strip())
     pypi_url = 'https://pypi.io/packages/source/%s/%s/%s' % (pack[0], pack, pypi_file)
-    if downloadUrllib2(pypi_url, dest, options):
-      comm = "mv %s/%s src.tar.gz; echo src.tar.gz > files.list" % (dest, pypi_file)
-      return downloadCmd(source, dest, options, comm, [])
     pack = pack + '==' + pkg[1].strip()
     pip_opts = "--no-deps --no-binary=:all:"
     pip="pip"


### PR DESCRIPTION
This allows downloading wheel even if source tarball exists