### PR TITLE
[Backport V00-31-XX] Sanitize return value of getuser()

### DIFF
--- a/cmsBuild
+++ b/cmsBuild
@@ -2502,7 +2502,7 @@ def parseOptions():
     uploadGroup.add_option("--upload-tmp-repository",
                            dest="uploadTmpRepository",
                            help="Name of temporary repository to use during upload. Default=cms.<username> (Deleted/recreated for each upload request)",
-                           default=getuser())
+                           default=re.sub("[^A-Za-z0-9]*", "", getuser())
 
     uploadGroup.add_option("--server-apt-env",
                            dest="serverAptEnv",


### PR DESCRIPTION
Backport of https://github.com/cms-sw/pkgtools/pull/200 used in IBs (see https://github.com/cms-sw/cms-bot/blob/master/config.map#L80-L83)