### PR TITLE
use git for patching on demand

### DIFF
--- a/cmsBuild
+++ b/cmsBuild
@@ -2738,7 +2738,7 @@ class Package(object):
                 sectionContents = self.sections[section][subsection].strip("\n ")
                 if sectionContents:
                     if saveScripts:
-                        if section in ["%prep"]:
+                        if section in ["%prep"] and self.options.useGitForPatches:
                             patchedContents = PATCH_SOURCE_MACROS
                             xpatchRE = re.compile("^\s*%patch[0-9]*\s+.+$")
                             for l in sectionContents.split("\n"):
@@ -3153,6 +3153,11 @@ def parseOptions():
                                     action="store_false",
                                     help="Do not delete the build area after successful build.",
                                     default=True)
+    advancedBuildOptions.add_option("--use-git-for-patches",
+                                    dest="useGitForPatches",
+                                    action="store_true",
+                                    help="Use git to record every patch applied to package sources.",
+                                    default=False)
     advancedBuildOptions.add_option("--pretend",
                                     dest="pretend",
                                     action="store_true",


### PR DESCRIPTION
To keep track of patches applied, by default `cmsBuild` was using `git init ; git add ; git commit` for each patch applied. This is a good way to create local patches when something failed but it consumes a lot time specially for packages with large code base ( pytorch, tensorflow etc.). This is a good option when debuging , so the PR proposes that by default `cmsBuild` do not use `git commit` for applied patches but one much enabled it using `--use-git-for-patches` command-line option