### PR TITLE
added CMSPKG_RPM_OPTS to install package from ref repo

### DIFF
--- a/cmsBuild
+++ b/cmsBuild
@@ -308,7 +308,7 @@ def install_reference(pkg):
         log("Command:\n %(command)s failed with the following message: %(output)s" % locals(), DEBUG)
         raise RpmInstallFailed(pkg, output)
     e, rpm_path = getstatusoutput("find %s -name '*.rpm'" % (tmp_path))
-    command = "%s ; rpm -Uvh --prefix %s %s" % (rpmEnvironmentScript, pkg.options.workDir, rpm_path)
+    command = "%s ; rpm -Uvh ${CMSPKG_RPM_OPTS} --prefix %s %s" % (rpmEnvironmentScript, pkg.options.workDir, rpm_path)
     error, output = getstatusoutput(command)
     if error:
         log("Command:\n %(command)s failed with the following message: %(output)s" % locals(), DEBUG)

--- a/cmsBuild_consts.py
+++ b/cmsBuild_consts.py
@@ -17,24 +17,25 @@ if [ ! -e "$REF/$PKG" ] ; then exit 0 ; fi
 mkdir -p "$DIR/$PKG"
 SCRAM_PROJECT=false
 if [ -d "$REF/$PKG/.SCRAM" ] ; then SCRAM_PROJECT=true ; fi
+rsync_cmd="rsync -a --no-group"
 for d in $(find "$REF/$PKG" -maxdepth 1 -mindepth 1 | sed 's|.*/||') ; do
   if [ "$d" = "etc" ] && [ -e "$REF/$PKG/etc/profile.d" ]  ; then
     mkdir "$DIR/$PKG/$d"
     for sd in $(find "$REF/$PKG/$d" -maxdepth 1 -mindepth 1 | sed 's|.*/||') ; do
       if [ "$sd" = "profile.d" ] && [ -e "$REF/$PKG/$d/$sd/init.sh" ] ; then
-        rsync -a "$REF/$PKG/$d/$sd/" "$DIR/$PKG/$d/$sd/"
+        $rsync_cmd "$REF/$PKG/$d/$sd/" "$DIR/$PKG/$d/$sd/"
       elif [ "$sd" = "scram.d" ] ; then
-        rsync -a "$REF/$PKG/$d/$sd/" "$DIR/$PKG/$d/$sd/"
+        $rsync_cmd "$REF/$PKG/$d/$sd/" "$DIR/$PKG/$d/$sd/"
       else
         ln -s "$REF/$PKG/$d/$sd" "$DIR/$PKG/$d/$sd"
       fi
     done
   elif [ "$d" = "tools" ] && [ -d "$REF/$PKG/$d/selected" ] ; then
-    rsync -a "$REF/$PKG/$d/" "$DIR/$PKG/$d/"
+    $rsync_cmd "$REF/$PKG/$d/" "$DIR/$PKG/$d/"
   elif [ "$SCRAM_PROJECT" = "true" ] && [ "$d" = ".SCRAM" ] ; then
-    rsync -a "$REF/$PKG/$d/" "$DIR/$PKG/$d/"
+    $rsync_cmd "$REF/$PKG/$d/" "$DIR/$PKG/$d/"
   elif [ "$SCRAM_PROJECT" = "true" ] && [ "$d" = "config" ] ; then
-    rsync -a "$REF/$PKG/$d/" "$DIR/$PKG/$d/"
+    $rsync_cmd "$REF/$PKG/$d/" "$DIR/$PKG/$d/"
   else
     ln -s $REF/$PKG/$d $DIR/$PKG/$d
   fi


### PR DESCRIPTION
`rpm -Uvh` for RPM version 4.20 need to be called with `--noplugins` option. Our distribution of RPM 4.20 set `CMSPKG_RPM_OPTS` env variable which should be then used by cmspkg and cmsBuild to properly install rpms. This Fix makes sure we set `CMSPKG_RPM_OPTS` when we install dummy packages using a ref install from cvmfs