### PR TITLE
Set the git remote before initialising the subpackages

### DIFF
--- a/cmsBuild
+++ b/cmsBuild
@@ -615,6 +615,7 @@ def downloadGit(source, dest, options):
     command = format("cd %(exportpath)s &&"
                      "git init &&"
                      "git pull --tags %(protocol)s%(gitroot)s refs/heads/%(branch)s &&"
+                     "git remote add origin %(protocol)s%(gitroot)s &&"
                      "git reset --hard %(tag)s && %(submodules)s"
                      "find . ! -path '%(filter)s' -delete &&"
                      "rm -rf .git .gitattributes .gitignore", **args)


### PR DESCRIPTION
Some repositories ([like OpenMPI](https://github.com/open-mpi/ompi/blob/main/.gitmodules)) use relative paths for the submodules.
This change makes it possible for `cmsBuild` to correctly initialise these submodules.