### PR TITLE
force done tasks in reverse order to avoid scheduler redo the same

### DIFF
--- a/cmsBuild
+++ b/cmsBuild
@@ -3815,7 +3815,7 @@ def buildPackage(pkg, scheduler, index, actions):
             scheduler.log("ObjectStore: Reused package %s from store." % pkg.pkgName())
             create_rpm_links()
             scheduler.log("Build successful %s." % pkg.pkgName())
-            for idx in range(index+1, len(actions)):
+            for idx in range(len(actions)-1, 0, -1):
                 scheduler.forceDone(actions[idx])
             return
 


### PR DESCRIPTION
We have hit a threading related issue where a task which was force done (pending to done) by `buildPackage` was retired by the ` __doRescheduleParallel` . The reason is that while `forceDone` was moving the tasks from `pending` to `done` queue the  ` __doRescheduleParallel` noticed that `build-build-<pkg>` is done and tried to start the `build-install-<pkg>` . This change process the task in reverse order so it marks forceDone in following order
1. build-rpms-pkg
2. build-srpm-pkg
3. build-install-pkg
4. build-build-pkg

this way ` __doRescheduleParallel`  will not try to process any of step1-3 as as build-build-pkg is marked forcedone at the end.

[a]
```
23:46:18 Creating directory /data/cmsbld/jenkins/workspace/build-any-ib/w/BUILD/el8_aarch64_gcc13/external/py3-jax/0.4.30-c4cfbfb81471703b473b3ae8ef025567 if not existing.
23:46:18 ObjectStore: Checking package store for external+py3-jax+0.4.30-c4cfbfb81471703b473b3ae8ef025567.
23:46:18 build-install-external+py3-jax+0.4.30-c4cfbfb81471703b473b3ae8ef025567 not in source list
23:46:18 Traceback (most recent call last):
23:46:18   File "PKGTOOLS/cmsBuild", line 5164, in <module>
23:46:18     build(opts, args[1:], PKGFactory)
23:46:18   File "PKGTOOLS/cmsBuild", line 4384, in build
23:46:18     buildSpecs(packages)
23:46:18   File "PKGTOOLS/cmsBuild", line 4308, in buildSpecs
23:46:18     scheduler.run()
23:46:18   File "/data/cmsbld/jenkins/workspace/build-any-ib/PKGTOOLS/scheduler.py", line 79, in run
23:46:18     self.__doNotifications()
23:46:18   File "/data/cmsbld/jenkins/workspace/build-any-ib/PKGTOOLS/scheduler.py", line 125, in __doNotifications
23:46:18     self.__doRescheduleParallel()
23:46:18   File "/data/cmsbld/jenkins/workspace/build-any-ib/PKGTOOLS/scheduler.py", line 203, in __doRescheduleParallel
23:46:18     transition(taskId, self.pendingJobs, self.runningJobs)
23:46:18   File "/data/cmsbld/jenkins/workspace/build-any-ib/PKGTOOLS/scheduler.py", line 20, in transition
23:46:18     raise e
23:46:18   File "/data/cmsbld/jenkins/workspace/build-any-ib/PKGTOOLS/scheduler.py", line 17, in transition
23:46:18     fromList.remove(what)
```