### PR TITLE
make sure the pending task is still in pendingJobs queue

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -19,7 +19,8 @@ def transition(what, fromList, toList, key="unknow"):
     toList.append(what)
   except ValueError as e:
     print (what + " not in source list")
-  return
+    return False
+  return True
 
 class Scheduler(object):
   # A simple job scheduler.
@@ -206,10 +207,12 @@ class Scheduler(object):
       else:
         buildJobs = buildJobs[:bldCount]
     for taskId in forceJobs + downloadJobs + buildJobs:
-      taskType = taskId.split("-")[0]
-      self.runningJobsCount[taskType] += 1
-      transition(taskId, self.pendingJobs, self.runningJobs, "parallel:pending->running")
-      self.__scheduleParallel(taskId, self.jobs[taskId]["spec"], priorty=self.jobs[taskId]["priorty"])
+      if transition(taskId, self.pendingJobs, self.runningJobs, "parallel:pending->running")
+        taskType = taskId.split("-")[0]
+        self.runningJobsCount[taskType] += 1
+        self.__scheduleParallel(taskId, self.jobs[taskId]["spec"], priorty=self.jobs[taskId]["priorty"])
+      elif self.resourceManager:
+        self.resourceManager.releaseResourcesForExternal(taskId)
 
   # Update the job with the result of running.
   def __updateJobStatus(self, taskId, error):

--- a/scheduler.py
+++ b/scheduler.py
@@ -147,12 +147,18 @@ class Scheduler(object):
     parallelJobs = [j for j in self.pendingJobs if self.jobs[j]["scheduler"] == "parallel"]
     # First of all clean up the pending parallel jobs from all those
     # which have broken dependencies.
-    for taskId in parallelJobs:
-      brokenDeps = [dep for dep in self.jobs[taskId]["deps"] if dep in self.brokenJobs]
-      if not brokenDeps:
-        continue
-      transition(taskId, self.pendingJobs, self.brokenJobs, "parallel:pending->broken")
-      self.errors[taskId] = "The following dependencies could not complete:\n%s" % "\n".join(brokenDeps)
+    while True:
+      has_broken = False
+      for taskId in parallelJobs[:]:
+        brokenDeps = [dep for dep in self.jobs[taskId]["deps"] if dep in self.brokenJobs]
+        if not brokenDeps:
+          continue
+        has_broken = True
+        parallelJobs.remove(taskId)
+        transition(taskId, self.pendingJobs, self.brokenJobs, "parallel:pending->broken")
+        self.errors[taskId] = "The following dependencies could not complete:\n%s" % "\n".join(brokenDeps)
+      if not has_broken:
+        break
 
     # If no tasks left, quit. Notice we need to check also for serial jobs
     # since they might queue more parallel payloads.
@@ -175,8 +181,7 @@ class Scheduler(object):
         if dumpMsg:
           self.log("Pending tasks: %s: %s" % (taskId, pendingDeps),30)
         continue
-      if taskId in self.pendingJobs:
-        allJobs.append({"id": taskId, "priorty": self.jobs[taskId]["priorty"]})
+      allJobs.append({"id": taskId, "priorty": self.jobs[taskId]["priorty"]})
     buildJobs =[]
     downloadJobs = []
     forceJobs = []

--- a/scheduler.py
+++ b/scheduler.py
@@ -207,7 +207,7 @@ class Scheduler(object):
       else:
         buildJobs = buildJobs[:bldCount]
     for taskId in forceJobs + downloadJobs + buildJobs:
-      if transition(taskId, self.pendingJobs, self.runningJobs, "parallel:pending->running")
+      if transition(taskId, self.pendingJobs, self.runningJobs, "parallel:pending->running"):
         taskType = taskId.split("-")[0]
         self.runningJobsCount[taskType] += 1
         self.__scheduleParallel(taskId, self.jobs[taskId]["spec"], priorty=self.jobs[taskId]["priorty"])

--- a/scheduler.py
+++ b/scheduler.py
@@ -16,10 +16,10 @@ def transition(what, fromList, toList, key="unknow"):
   try:
     print("DEBUG:%s: transition %s" % (key, what))
     fromList.remove(what)
+    toList.append(what)
   except ValueError as e:
     print (what + " not in source list")
-    raise e
-  toList.append(what)
+  return
 
 class Scheduler(object):
   # A simple job scheduler.
@@ -181,7 +181,8 @@ class Scheduler(object):
         if dumpMsg:
           self.log("Pending tasks: %s: %s" % (taskId, pendingDeps),30)
         continue
-      allJobs.append({"id": taskId, "priorty": self.jobs[taskId]["priorty"]})
+      if taskId in self.pendingJobs:
+        allJobs.append({"id": taskId, "priorty": self.jobs[taskId]["priorty"]})
     buildJobs =[]
     downloadJobs = []
     forceJobs = []

--- a/scheduler.py
+++ b/scheduler.py
@@ -175,7 +175,8 @@ class Scheduler(object):
         if dumpMsg:
           self.log("Pending tasks: %s: %s" % (taskId, pendingDeps),30)
         continue
-      allJobs.append({"id": taskId, "priorty": self.jobs[taskId]["priorty"]})
+      if taskId in self.pendingJobs:
+        allJobs.append({"id": taskId, "priorty": self.jobs[taskId]["priorty"]})
     buildJobs =[]
     downloadJobs = []
     forceJobs = []


### PR DESCRIPTION
possible fix for errors like [a] where a package `build-prep` step force mark some tasks done but scheduler still try to schedule them.

[a]
```
DEBUG:parallel:pending->running: transition build-prep-external+py3-Bottleneck+1.5.0-391a8d83ba581644e136a881814f97c1
Creating directory /pool/condor/dir_2570169/jenkins/workspace/build-any-ib/w/BUILD/el8_aarch64_gcc14/external/py3-Bottleneck/1.5.0-391a8d83ba581644e136a881814f97c1 if not existing.
Creating directory /pool/condor/dir_2570169/jenkins/workspace/build-any-ib/w/BUILD/el8_aarch64_gcc14/external/py3-histogrammar/1.1.2-3ad18a1c123188fe94496a66b86ed231 if not existing.
ObjectStore: Checking package store for external+py3-Bottleneck+1.5.0-391a8d83ba581644e136a881814f97c1.
DEBUG:Force:pending->done: transition build-rpms-external+py3-Bottleneck+1.5.0-391a8d83ba581644e136a881814f97c1
DEBUG:Force:pending->done: transition build-srpm-external+py3-Bottleneck+1.5.0-391a8d83ba581644e136a881814f97c1
DEBUG:Force:pending->done: transition build-install-external+py3-Bottleneck+1.5.0-391a8d83ba581644e136a881814f97c1
DEBUG:Force:pending->done: transition build-build-external+py3-Bottleneck+1.5.0-391a8d83ba581644e136a881814f97c1
DEBUG:parallel:pending->running: transition build-install-external+py3-Bottleneck+1.5.0-391a8d83ba581644e136a881814f97c1
build-install-external+py3-Bottleneck+1.5.0-391a8d83ba581644e136a881814f97c1 not in source list
Traceback (most recent call last):
  File "PKGTOOLS/cmsBuild", line 5196, in <module>
    build(opts, args[1:], PKGFactory)
  File "PKGTOOLS/cmsBuild", line 4416, in build
    buildSpecs(packages)
  File "PKGTOOLS/cmsBuild", line 4327, in buildSpecs
    scheduler.run()
  File "/pool/condor/dir_2570169/jenkins/workspace/build-any-ib/PKGTOOLS/scheduler.py", line 80, in run
    self.__doNotifications()
  File "/pool/condor/dir_2570169/jenkins/workspace/build-any-ib/PKGTOOLS/scheduler.py", line 126, in __doNotifications
    self.__doRescheduleParallel()
  File "/pool/condor/dir_2570169/jenkins/workspace/build-any-ib/PKGTOOLS/scheduler.py", line 204, in __doRescheduleParallel
    transition(taskId, self.pendingJobs, self.runningJobs, "parallel:pending->running")
  File "/pool/condor/dir_2570169/jenkins/workspace/build-any-ib/PKGTOOLS/scheduler.py", line 21, in transition
    raise e
  File "/pool/condor/dir_2570169/jenkins/workspace/build-any-ib/PKGTOOLS/scheduler.py", line 18, in transition
    fromList.remove(what)
ValueError: list.remove(x): x not in list

```