### PR TITLE
Do not find pkg auto provide/requires for selected data package

### DIFF
--- a/build-system-env.sh
+++ b/build-system-env.sh
@@ -6,4 +6,5 @@ export MESON_NUM_PROCESSES="$1"
 export OMP_NUM_THREADS="$1"
 export OMP_THREAD_LIMIT="$1"
 export OMP_DYNAMIC=FALSE
+export CARGO_BUILD_JOBS="$1"
 export CARGO_HOME="${TMPDIR}/cargo_home"

--- a/build-system-env.sh
+++ b/build-system-env.sh
@@ -1,0 +1,9 @@
+export CMAKE_BUILD_PARALLEL_LEVEL="$1"
+export MAX_JOBS="$1"
+export NINJA_NUM_JOBS="$1"
+export CYTHON_NTHREADS="$1"
+export MESON_NUM_PROCESSES="$1"
+export OMP_NUM_THREADS="$1"
+export OMP_THREAD_LIMIT="$1"
+export OMP_DYNAMIC=FALSE
+export CARGO_HOME="${TMPDIR}/cargo_home"

--- a/cmsBuild
+++ b/cmsBuild
@@ -2211,6 +2211,7 @@ class SubPackage(object):
             self.cmsplatf, self.group, self.name, self.version, '1', self.pkgRevision, self.cmsplatf)
         self.srpmfilename = parent.srpmfilename
         self.pkginstroot = parent.pkginstroot
+        self.noCompilerOption = parent.noCompilerOption
         self.parent = parent
 
     def dumpSpecFragment(self, computeSpecChecksum=True):

--- a/cmsBuild
+++ b/cmsBuild
@@ -3900,6 +3900,7 @@ def buildPackage(pkg, scheduler, index, actions):
                        " %(rpmenv)s; source %(pkgtools)s/build-system-env.sh %(compiling_processes)s;" \
                        " %(prefix)s" \
                        " rpmbuild %(nodeps)s --noclean --buildroot %(buildRoot)s %(rpmbuild_stage)s" \
+                       " --define '_smp_build_nthreads %(compiling_processes)s" \
                        " --define '_topdir %(topdir)s' %(makeprocesses)s %(ignoreCompileErrors)s" \
                        " --define '_builddir %(_builddir)s' %(extraRpmDefines)s" \
                        " %(spec)s >>%(logfile)s 2>&1" % optionsDict

--- a/cmsBuild
+++ b/cmsBuild
@@ -3901,7 +3901,7 @@ def buildPackage(pkg, scheduler, index, actions):
                        " %(rpmenv)s; source %(pkgtools)s/build-system-env.sh %(compiling_processes)s;" \
                        " %(prefix)s" \
                        " rpmbuild %(nodeps)s --noclean --buildroot %(buildRoot)s %(rpmbuild_stage)s" \
-                       " --define '_smp_build_nthreads %(compiling_processes)s" \
+                       " --define '_smp_build_nthreads %(compiling_processes)s'" \
                        " --define '_topdir %(topdir)s' %(makeprocesses)s %(ignoreCompileErrors)s" \
                        " --define '_builddir %(_builddir)s' %(extraRpmDefines)s" \
                        " %(spec)s >>%(logfile)s 2>&1" % optionsDict

--- a/cmsBuild
+++ b/cmsBuild
@@ -25,7 +25,7 @@ import itertools
 import pickle
 from hashlib import sha256
 from cmsBuild_consts import *
-from cmsdist_config import USE_COMPILER_VERSION, NO_VERSION_SUFFIX, NO_AUTO_RUNPATH
+from cmsdist_config import USE_COMPILER_VERSION, NO_VERSION_SUFFIX, NO_AUTO_RUNPATH, DISABLE_AUTO_PROVIDE_REQUIRES
 try: from monitor_build import run_monitor_on_command
 except: run_monitor_on_command=None
 import json
@@ -100,6 +100,12 @@ def cmsdist_file(name, ext, options, pkgname):
 def isNoVersionSuffix(name):
   for reg in NO_VERSION_SUFFIX:
     if reg.match(name): return True
+  return False
+
+def disableAutoProvideRequires(pkg):
+  if pkg.noCompilerOption:
+    for reg in DISABLE_AUTO_PROVIDE_REQUIRES:
+      if reg.match(pkg.name): return True
   return False
 
 # Minimal string sanitization.
@@ -2340,6 +2346,7 @@ class Package(object):
         self.buildWithRunPath = options.buildWithRunPath
         self.globalBuildOptions = ""
         self.buildOptions = ""
+        self.noCompilerOption = False
 
     def rpmLocation(self):
         return join(self.rpmdir, self.rpmfilename)
@@ -2396,6 +2403,7 @@ class Package(object):
             self.requiresStatement = ""
             self.compilerRealVersion = self.realVersion
             self.expandSpec()
+            self.noCompilerOption = parseNoCompilerLine(self.spec)
         else:
             if (not self.name in compiler_package_dependency) and (not PKGFactory.has_key(compilerName)):
                 compilerPKG = None
@@ -2407,10 +2415,11 @@ class Package(object):
             if PKGFactory.has_key(compilerName):
                 self.compilerRealVersion = PKGFactory[compilerName].realVersion
             self.expandSpec()
-            if self.options.systemCompiler == False and parseNoCompilerLine(self.spec) == False:
+            self.noCompilerOption = parseNoCompilerLine(self.spec)
+            if self.options.systemCompiler == False and self.noCompilerOption == False:
                 self.dependencies.append(compilerName)
                 self.origDependencies.append(compilerName)
-        if parseNoCompilerLine(self.spec): self.buildWithRunPath = False
+        if self.noCompilerOption: self.buildWithRunPath = False
         if isNoVersionSuffix(self.name):
             self.versionSuffix = False
         else:
@@ -3204,6 +3213,11 @@ def parseOptions():
                                     help="Ignores CMSSW compilation errors.",
                                     action="store_true",
                                     default=False)
+    advancedBuildOptions.add_option("--fail-on-missing-dependency",
+                                    dest="failOnMissingDependency",
+                                    help="Fail package build if there are missing dependencies.",
+                                    action="store_true",
+                                    default=False)
     advancedBuildOptions.add_option("--no-bootstrap",
                                     dest="bootstrap",
                                     action="store_false",
@@ -3873,7 +3887,13 @@ def buildPackage(pkg, scheduler, index, actions):
         optionsDict["spec"] = pkg.finalSpecFilenameForPackaging()
         scheduler.log("Building %s. Log can be found in %s." % (pkg.name, logfile))
 
-    rpmbuild_stages = ["-bp", "-bc --short-circuit", "-bi --short-circuit", "-bs --short-circuit", "-bb"]
+    # Always disable auto Provides/Requires for install step (-bi)
+    # Disabled auto Provides/Requires for final step (-bb) for selected packages e.g data packages
+    disableProvReqFlags = "--define '__find_requires %{nil}'  --define '__find_provides %{nil}'"
+    disableProvReq = ""
+    if disableAutoProvideRequires(pkg):
+        disableProvReq = disableProvReqFlags
+    rpmbuild_stages = ["-bp", "-bc --short-circuit", "-bi --short-circuit %s" % disableProvReqFlags, "-bs --short-circuit", "-bb " + disableProvReq]
     optionsDict["rpmbuild_stage"] = rpmbuild_stages[index]
     rpmbuildCommand = "CMSBUILD_PACKAGE=%(pkgname)s;  export _CMSBUILD_BUILD_ENV_=1; " \
                        " %(rpmenv)s;" \
@@ -4070,7 +4090,10 @@ def checkDeps(pkg, requires, scheduler):
             for p in provides[req]:
                 if p == pkg_name: continue
                 found[p] = 1
-    print("Missing ",pkg.name,missing)
+    if missing:
+        print("Missing ",pkg.name, missing)
+        if pkg.options.failOnMissingDependency:
+            raise RpmBuildFailed(pkg)
     scheduler.log("Done checking package dependencies: %s" % pkg.pkgName())
     return
 

--- a/cmsBuild
+++ b/cmsBuild
@@ -3313,6 +3313,8 @@ def parseOptions():
                                     default=False, help="Use the new scheduler to install / build packages")
     advancedBuildOptions.add_option("--monitor", dest="enableMonitor", action="store_true",
                                     default=False, help="Enable rpmbuild jobs stats monitoring")
+    advancedBuildOptions.add_option("--monitor-commands", dest="enableMonitorCommands", action="store_true",
+                                    default=False, help="Record the running commands during stats monitoring.")
     advancedBuildOptions.add_option("--ldps", "--log-deps",
                                     dest="depsLog", action="store_true",
                                     default=False, help="store json formatted log of dependencies in workDir/WEB/arch")
@@ -3860,18 +3862,17 @@ def buildPackage(pkg, scheduler, index, actions):
                 scheduler.forceDone(actions[idx])
             return
 
-    if pkg.options.compilingProcesses:
-        optionsDict["makeprocesses"] = "--define \"compiling_processes %s\"" % pkg.options.compilingProcesses
+    jobs = pkg.options.compilingProcesses if pkg.options.compilingProcesses else 1
+    optionsDict["makeprocesses"] = "--define \"compiling_processes %s\"" % jobs
     if pkg.options.ignoreCompileErrors:
         optionsDict["ignoreCompileErrors"] = "--define \"ignore_compile_errors 1\""
+    optionsDict["compiling_processes"] = jobs
+    optionsDict["pkgtools"] = pkgtools_dir
     optionsDict["tmpdir"] = join(opts.workDir, opts.tempDirPrefix)
     optionsDict["xtmpdir"] = join(pkg.builddir, 'cmsdist-tmp')
     optionsDict["rpmenv"] = rpmEnvironmentScript
-    optionsDict["xenv"] = ""
     optionsDict["_builddir"] = pkg.builddir
     optionsDict["spec"] = "%s/spec" % pkg.specdir
-    if 'rust' in pkg.fullDependencies:
-      optionsDict["xenv"] = "CARGO_HOME=%s/cargo_home" % optionsDict["tmpdir"]
     optionsDict.update({"prefix": getCommandPrefix(pkg.options),
                         "buildRoot": join(optionsDict["tmpdir"], "BUILDROOT", pkg.checksum),
                         "extraRpmDefines": getRpmDefines()})
@@ -3895,9 +3896,9 @@ def buildPackage(pkg, scheduler, index, actions):
         disableProvReq = disableProvReqFlags
     rpmbuild_stages = ["-bp", "-bc --short-circuit", "-bi --short-circuit %s" % disableProvReqFlags, "-bs --short-circuit", "-bb " + disableProvReq]
     optionsDict["rpmbuild_stage"] = rpmbuild_stages[index]
-    rpmbuildCommand = "CMSBUILD_PACKAGE=%(pkgname)s;  export _CMSBUILD_BUILD_ENV_=1; " \
-                       " %(rpmenv)s;" \
-                       " TMPDIR=%(xtmpdir)s %(xenv)s %(prefix)s" \
+    rpmbuildCommand = "CMSBUILD_PACKAGE=%(pkgname)s;  export _CMSBUILD_BUILD_ENV_=1; export TMPDIR=%(xtmpdir)s; " \
+                       " %(rpmenv)s; source %(pkgtools)s/build-system-env.sh %(compiling_processes)s;" \
+                       " %(prefix)s" \
                        " rpmbuild %(nodeps)s --noclean --buildroot %(buildRoot)s %(rpmbuild_stage)s" \
                        " --define '_topdir %(topdir)s' %(makeprocesses)s %(ignoreCompileErrors)s" \
                        " --define '_builddir %(_builddir)s' %(extraRpmDefines)s" \
@@ -3926,7 +3927,8 @@ def buildPackage(pkg, scheduler, index, actions):
         monitor_file_suffix = "-%s" % action_name
         if monitor_file_suffix == "-build":
             monitor_file_suffix = ""
-        error, output = run_monitor_on_command(rpmbuildCommand, "%s/%s%s.json" % (pkg.builddir, pkg.name, monitor_file_suffix))
+        json_output = "%s/%s%s.json" % (pkg.builddir, pkg.name, monitor_file_suffix)
+        error, output = run_monitor_on_command(rpmbuildCommand, json_output, opts.enableMonitorCommands)
     else:
         error, output = getstatusoutput(rpmbuildCommand)
 

--- a/cmsdist_config.py
+++ b/cmsdist_config.py
@@ -5,4 +5,8 @@ NO_VERSION_SUFFIX = [
   compile("fwlite"), compile("fwlite-patch"),
   compile("^data-[A-Z][A-Za-z0-9]+-[A-Za-z][A-Za-z0-9]+$")
 ]
+DISABLE_AUTO_PROVIDE_REQUIRES = [
+  compile("^data-[A-Z][A-Za-z0-9]+-[A-Za-z][A-Za-z0-9]+$"),
+  compile("^geant4-G4[a-zA-Z0-9]+$")
+]
 NO_AUTO_RUNPATH = []

--- a/monitor_build.py
+++ b/monitor_build.py
@@ -8,11 +8,13 @@ from time import time, sleep, monotonic
 SAMPLE_INTERVAL = 1.0
 cpu_times = {}
 
-def update_monitor_stats(proc):
+def update_monitor_stats(proc, commands=False):
     global cpu_times
     try:children = proc.children(recursive=True)
     except: return {}
     stats = {"rss": 0, "vms": 0, "shared": 0, "data": 0, "uss": 0, "pss": 0, "num_fds": 0, "num_threads": 0, "processes": 0, "cpu": 0}
+    if commands:
+        stats["commands" ] = []
     stats['processes'] = len(children)
     sleep(SAMPLE_INTERVAL)
     new_cpu_times = {}
@@ -30,8 +32,12 @@ def update_monitor_stats(proc):
             else:
                 delta = new_cpu.user + new_cpu.system
                 elapsed = time() - p.create_time()
+            pcpu = 0
             if elapsed>=0.1:
-                stats["cpu"] += int((delta / elapsed) * 100.0)
+                pcpu = int((delta / elapsed) * 100.0)
+                stats["cpu"] += pcpu
+            if commands:
+                stats["commands"].append({"pid": pid, "command": p.cmdline(), "old_cpu": old_cpu, "new_cpu": new_cpu, "delta": delta, "elapsed": elapsed, "cpu": pcpu})
             new_cpu_times[pid] = (new_cpu, current_time)
         except:
             continue
@@ -50,12 +56,12 @@ def update_monitor_stats(proc):
     cpu_times = new_cpu_times
     return stats
 
-def monitor_stats(p_id, stats_file_name):
+def monitor_stats(p_id, stats_file_name, commands=False):
     stime = int(time())
     p = psutil.Process(p_id)
     data = []
     while p.is_running():
-        stats = update_monitor_stats(p)
+        stats = update_monitor_stats(p, commands)
         if not stats:
             sleep(SAMPLE_INTERVAL)
             continue
@@ -65,9 +71,9 @@ def monitor_stats(p_id, stats_file_name):
         json_dump(data, sf)
     return
 
-def run_monitor_on_command(command_to_monitor, stats_file_name):
+def run_monitor_on_command(command_to_monitor, stats_file_name, commands=False):
     p = subprocess.Popen(command_to_monitor, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds= True)
-    mon_thd = Thread(target=monitor_stats, args=(p.pid, stats_file_name,))
+    mon_thd = Thread(target=monitor_stats, args=(p.pid, stats_file_name, commands,))
     mon_thd.start()
     stout, sterr = p.communicate() # this blocks until the process is finished
     mon_thd.join() # wait for monitoring thread to write its output


### PR DESCRIPTION
By default `rpmbuild` runs `rpmdeps` for all packages unless explicitly disabled via `AutoReqProv: no`. For cmssw and geant4 data packages we can always tell cmsBuild to not run the  `rpmdeps` . This can save some build time for large data packages e.g. for `geant4-G4EMLOW` (which has over 11K files) this change can save 30secs of build time

Also added new command line option to fail the buidl if there are missing dependencies. We can enable it for 16.1.X where dependency of all packages should be clean. 

cmsBuild now also set build system env to control the number of parallel obs to run. For most of build recepies we explicitly use `-j N` but for many `pypi` based packages we sometime can not control the parallel build jobs. Setting these env will allow the backend build system e.g. cmake. ninja or openmp to run the parallel jobs in a control way (instead of uses all the cores)